### PR TITLE
Add the abilty to overwrite the version during the build

### DIFF
--- a/src/helpers/version.rs
+++ b/src/helpers/version.rs
@@ -1,1 +1,5 @@
-pub const VERSION: &str = env!("CARGO_PKG_VERSION");
+// pub const VERSION: &str = option_env!("GUITAR_BUILD_OVERWRITE_VERSION").unwrap_or(env!("CARGO_PKG_VERSION")); // require unstable for now
+pub const VERSION: &str = match option_env!("GUITAR_BUILD_OVERWRITE_VERSION") {
+    Some(v) => v,
+    None => env!("CARGO_PKG_VERSION"),
+};


### PR DESCRIPTION
Hi,
In some cases you may want to append a custom string to the version that cargo would normally reject. e.g. git hash

a simple solution is that we allow the builder from setting an environment variable (`GUITAR_BUILD_OVERWRITE_VERSION`) and use it when available and use `CARGO_PKG_VERSION` otherwise

something a package like [1] could make use of, and provide a more accurate build that outputs the version+commit of the build

[1]: https://aur.archlinux.org/packages/git-guitar-git