### PR TITLE
Support opening bare repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ This README and the in-app settings/help view are the current source of truth fo
 ## Requirements
 
 - Rust and Cargo when building from source.
-- A non-bare Git repository. Bare repositories are not supported by the UI.
+- A Git repository. Bare repositories can be opened for history browsing.
 - `user.name` and `user.email` configured in Git before opening a repository. `guitar` reads these on repository load and uses them when creating commits.
 - Terminal mouse support for pane dragging and wheel scrolling.
 - SSH or HTTPS credentials for private remotes when using network operations.
@@ -141,7 +141,7 @@ guitar -v
 guitar --reset
 ```
 
-`--version` and `-v` print the version and exit. `--reset` deletes the saved `guitar` config directory, then starts the app with regenerated defaults.
+`--version` and `-v` print the version and exit. `--reset` deletes the saved `guitar` config directory, then starts the app with regenerated defaults. Bare repositories skip workdir status loading automatically. Worktree-changing commands, including checkout, reset, staging, committing, stash, cherry-pick, revert, rebase, and merge operations, remain unavailable when the current repository has no worktree.
 
 If the path cannot be opened as a Git repository, `guitar` falls back to the splash screen and shows saved recent repositories.
 

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -14,7 +14,7 @@ use crate::{
     helpers::{
         branch_visibility::{current_branch_names, load_branch_visibility, prune_hidden_branches, save_branch_visibility},
         heatmap::{DAYS, WEEKS, empty_heatmap},
-        keymap::{Command, KeyBinding, KeymapEditError, KeymapSelection},
+        keymap::{Command, KeyBinding, KeymapEditError, KeymapSelection, RepoCapability},
         layout::LayoutConfig,
         localisation::{Language, errors, load_language, load_language_from_path, modal, operations, save_language, save_language_to_path, set_active_language, settings},
         recent::{load_recent, save_recent, save_recent_to_path},
@@ -39,7 +39,7 @@ use crate::{
         actions::network::NetworkRequest,
         queries::{
             commits::get_git_user_info,
-            diffs::get_filenames_diff_at_workdir,
+            diffs::get_uncommitted_changes,
             helpers::{FileChange, UncommittedChanges},
         },
     },
@@ -77,6 +77,29 @@ pub enum Viewport {
     Viewer,
     Splash,
     Settings,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WorktreeState {
+    Available,
+    Unavailable,
+}
+
+impl WorktreeState {
+    pub fn from_repo(repo: &Repository) -> Self {
+        if repo.is_bare() || repo.workdir().is_none() { Self::Unavailable } else { Self::Available }
+    }
+
+    pub fn has_worktree(self) -> bool {
+        matches!(self, Self::Available)
+    }
+
+    pub(crate) fn supports(self, capability: RepoCapability) -> bool {
+        match self {
+            Self::Available => true,
+            Self::Unavailable => !capability.requires_worktree(),
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -650,6 +673,8 @@ pub struct App {
 
     // Main loop shutdown flag.
     pub is_exit: bool,
+
+    pub worktree_state: WorktreeState,
 }
 
 impl App {
@@ -929,10 +954,12 @@ impl App {
         let absolute_path = absolute_path.display().to_string();
         self.path = Some(absolute_path.clone());
         self.repo = repo;
+        self.worktree_state = WorktreeState::Available;
         self.refresh_theme_assets();
 
         // Repository-specific state starts only after Repository::open succeeds.
         if let Some(repo) = &self.repo {
+            self.worktree_state = WorktreeState::from_repo(repo);
             let current_path = PathBuf::from(&absolute_path);
             self.worktrees = Worktrees::from_entries(list_worktrees(repo, Some(current_path.as_path())).unwrap_or_default());
             self.submodules = Submodules::from_entries(list_submodules(repo).unwrap_or_default());
@@ -968,10 +995,17 @@ impl App {
                 });
             }
 
-            // Commit actions require a concrete identity, so missing config is treated as fatal.
-            let (name, email) = get_git_user_info(repo).expect("Couldn't get user credentials");
-            self.name = name.unwrap();
-            self.email = email.unwrap();
+            match get_git_user_info(repo) {
+                Ok((Some(name), Some(email))) => {
+                    self.name = name;
+                    self.email = email;
+                },
+                Ok(_) => {
+                    self.name.clear();
+                    self.email.clear();
+                },
+                Err(error) => self.show_error(errors::with_error(errors::COMMIT(), error)),
+            }
 
             // The spinner reflects walker activity, not individual git network commands.
             self.spinner.start();
@@ -1035,10 +1069,9 @@ impl App {
                         self.viewport = Viewport::Graph;
                     }
 
-                    match get_filenames_diff_at_workdir(repo) {
-                        Ok(uncommitted) => {
-                            self.uncommitted = uncommitted;
-                        },
+                    match get_uncommitted_changes(repo) {
+                        Ok(Some(uncommitted)) => self.uncommitted = uncommitted,
+                        Ok(None) => self.uncommitted = UncommittedChanges::clean(),
                         Err(error) => {
                             self.uncommitted = UncommittedChanges::default();
                             self.show_error(errors::with_error(errors::FILE_DIFF(), error));

--- a/src/app/input/context_menu.rs
+++ b/src/app/input/context_menu.rs
@@ -125,7 +125,7 @@ impl App {
         let mut items = regular_items;
         Self::append_context_menu_section(&mut items, action_items);
         Self::append_context_menu_section(&mut items, navigation_items);
-        items
+        items.into_iter().map(|item| self.context_menu_item_with_availability(item)).collect()
     }
 
     fn append_context_menu_section(items: &mut Vec<ContextMenuItem>, section: Vec<ContextMenuItem>) {
@@ -162,6 +162,15 @@ impl App {
             ContextMenuAction::Command(command) | ContextMenuAction::GraphCommand(command) => self.command_is_action_mode_only(command),
             _ => false,
         }
+    }
+
+    fn context_menu_item_with_availability(&self, mut item: ContextMenuItem) -> ContextMenuItem {
+        if let ContextMenuAction::Command(command) | ContextMenuAction::GraphCommand(command) = &item.action
+            && !self.command_is_available(command)
+        {
+            item.enabled = false;
+        }
+        item
     }
 
     fn command_is_action_mode_only(&self, command: &Command) -> bool {

--- a/src/app/input/git.rs
+++ b/src/app/input/git.rs
@@ -175,6 +175,10 @@ impl App {
         let Some(action) = self.pending_operation_action.take() else {
             return;
         };
+        self.run_pending_workdir_operation_action(action);
+    }
+
+    fn run_pending_workdir_operation_action(&mut self, action: PendingOperationAction) {
         let Some(path) = self.repo.as_ref().map(|repo| repo.path().to_path_buf()) else {
             self.focus = Focus::Viewport;
             self.show_error(errors::GIT_OPERATION_NO_REPOSITORY());
@@ -360,68 +364,33 @@ impl App {
     }
 
     pub fn on_drop(&mut self) {
-        if self.repo.is_none() || self.viewport != Viewport::Graph {
-            return;
-        }
-
-        let oid = match self.focus {
-            Focus::Viewport => {
-                let Some(row) = self.graph_row_at(self.graph_selected) else {
-                    return;
-                };
-                if !row.is_stash {
-                    return;
-                }
-                row.oid
-            },
-            Focus::Stashes => {
-                let Some(alias) = self.stash_alias_at_pane_selection() else {
-                    return;
-                };
-                *self.oids.get_oid_by_alias(alias)
-            },
-            _ => return,
-        };
-
-        let Some(path) = self.repo.as_ref().map(|repo| repo.path().to_path_buf()) else {
-            return;
-        };
-        let mut repo = match Repository::open(path) {
-            Ok(repo) => repo,
-            Err(error) => {
-                self.show_error(errors::with_error(errors::OPEN_REPOSITORY(), error));
-                return;
-            },
-        };
-        match pop(&mut repo, &oid, false) {
-            Ok(_) => self.reload(None),
-            Err(error) => self.show_error(errors::with_error(errors::DROP_STASH(), error)),
-        }
+        self.apply_selected_stash(false, errors::DROP_STASH());
     }
 
     pub fn on_pop(&mut self) {
+        self.apply_selected_stash(true, errors::POP_STASH());
+    }
+
+    fn selected_stash_oid(&self) -> Option<git2::Oid> {
+        match self.focus {
+            Focus::Viewport => {
+                let row = self.graph_row_at(self.graph_selected)?;
+                row.is_stash.then_some(row.oid)
+            },
+            Focus::Stashes => {
+                let alias = self.stash_alias_at_pane_selection()?;
+                Some(*self.oids.get_oid_by_alias(alias))
+            },
+            _ => None,
+        }
+    }
+
+    fn apply_selected_stash(&mut self, reinstate_index: bool, error_title: &'static str) {
         if self.repo.is_none() || self.viewport != Viewport::Graph {
             return;
         }
 
-        let oid = match self.focus {
-            Focus::Viewport => {
-                let Some(row) = self.graph_row_at(self.graph_selected) else {
-                    return;
-                };
-                if !row.is_stash {
-                    return;
-                }
-                row.oid
-            },
-            Focus::Stashes => {
-                let Some(alias) = self.stash_alias_at_pane_selection() else {
-                    return;
-                };
-                *self.oids.get_oid_by_alias(alias)
-            },
-            _ => return,
-        };
+        let Some(oid) = self.selected_stash_oid() else { return };
 
         let Some(path) = self.repo.as_ref().map(|repo| repo.path().to_path_buf()) else {
             return;
@@ -433,9 +402,9 @@ impl App {
                 return;
             },
         };
-        match pop(&mut repo, &oid, true) {
+        match pop(&mut repo, &oid, reinstate_index) {
             Ok(_) => self.reload(None),
-            Err(error) => self.show_error(errors::with_error(errors::POP_STASH(), error)),
+            Err(error) => self.show_error(errors::with_error(error_title, error)),
         }
     }
 
@@ -747,11 +716,8 @@ impl App {
     pub fn on_commit(&mut self) {
         match self.viewport {
             Viewport::Settings | Viewport::Viewer => {},
-            _ => {
-                if self.uncommitted.is_staged {
-                    self.focus = Focus::ModalCommit;
-                }
-            },
+            _ if self.uncommitted.is_staged => self.focus = Focus::ModalCommit,
+            _ => {},
         }
     }
 
@@ -1159,28 +1125,30 @@ impl App {
 
     pub fn on_continue_operation(&mut self) {
         let Some(repo) = &self.repo else { return };
-        if matches!(self.viewport, Viewport::Settings | Viewport::Viewer) || self.focus != Focus::Viewport || Self::active_operation_kind(repo).is_none() {
+        if matches!(self.viewport, Viewport::Settings | Viewport::Viewer) || self.focus != Focus::Viewport {
             return;
         }
 
-        let kind = Self::active_operation_kind(repo).unwrap();
-        self.pending_operation_action = Some(PendingOperationAction::Continue);
-        self.modal_operation_kind = kind;
-        self.modal_operation_message = operations::continuing(kind.label());
-        self.focus = Focus::ModalOperationProgress;
+        if let Some(kind) = Self::active_operation_kind(repo) {
+            self.pending_operation_action = Some(PendingOperationAction::Continue);
+            self.modal_operation_kind = kind;
+            self.modal_operation_message = operations::continuing(kind.label());
+            self.focus = Focus::ModalOperationProgress;
+        }
     }
 
     pub fn on_abort_operation(&mut self) {
         let Some(repo) = &self.repo else { return };
-        if matches!(self.viewport, Viewport::Settings | Viewport::Viewer) || self.focus != Focus::Viewport || Self::active_operation_kind(repo).is_none() {
+        if matches!(self.viewport, Viewport::Settings | Viewport::Viewer) || self.focus != Focus::Viewport {
             return;
         }
 
-        let kind = Self::active_operation_kind(repo).unwrap();
-        self.pending_operation_action = Some(PendingOperationAction::Abort);
-        self.modal_operation_kind = kind;
-        self.modal_operation_message = operations::aborting(kind.label());
-        self.focus = Focus::ModalOperationProgress;
+        if let Some(kind) = Self::active_operation_kind(repo) {
+            self.pending_operation_action = Some(PendingOperationAction::Abort);
+            self.modal_operation_kind = kind;
+            self.modal_operation_message = operations::aborting(kind.label());
+            self.focus = Focus::ModalOperationProgress;
+        }
     }
 }
 

--- a/src/app/input/handler.rs
+++ b/src/app/input/handler.rs
@@ -1,6 +1,7 @@
 use crate::{
     app::app::{App, Focus, Viewport},
     helpers::keymap::{Command, InputMode, KeyBinding, command_for_key_binding, load_or_init_keymaps},
+    helpers::localisation::errors,
 };
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
@@ -43,7 +44,16 @@ impl App {
         }
     }
 
+    pub(crate) fn command_is_available(&self, command: &Command) -> bool {
+        self.worktree_state.supports(command.required_capability())
+    }
+
     pub(crate) fn dispatch_command(&mut self, command: &Command) {
+        if !self.command_is_available(command) {
+            self.show_error(errors::BARE_REPO_WORKDIR_OPERATION());
+            return;
+        }
+
         match command {
             Command::WidenScope => self.on_widen_scope(),
             Command::NarrowScope => self.on_narrow_scope(),

--- a/src/app/state/defaults.rs
+++ b/src/app/state/defaults.rs
@@ -7,7 +7,7 @@ use crate::{
 };
 use crate::{
     app::{
-        app::{App, AuthInputField, BranchModalAction, Focus, OperationKind, RemoteInputAction, SettingsTab, Viewport, WorktreeModalAction},
+        app::{App, AuthInputField, BranchModalAction, Focus, OperationKind, RemoteInputAction, SettingsTab, Viewport, WorktreeModalAction, WorktreeState},
         state::layout::Layout,
     },
     core::{branches::Branches, oids::Oids, tags::Tags},
@@ -239,6 +239,7 @@ impl Default for App {
 
             // Exit
             is_exit: false,
+            worktree_state: WorktreeState::Available,
         }
     }
 }

--- a/src/git/queries/diffs.rs
+++ b/src/git/queries/diffs.rs
@@ -1,18 +1,24 @@
 use crate::{
     git::queries::helpers::{ConflictFile, FileChange, FileStatus, Hunk, UncommittedChanges, deduplicate, diff_to_hunks, walk_tree},
-    helpers::text::{decode, sanitize},
+    helpers::{
+        localisation::errors,
+        text::{decode, sanitize},
+    },
 };
-use git2::{Delta, DiffOptions, Error, Oid, Repository, StatusOptions, Submodule, SubmoduleIgnore, SubmoduleStatus};
+use git2::{Delta, DiffOptions, Error, Oid, Repository, Status, StatusOptions, Submodule, SubmoduleIgnore, SubmoduleStatus};
 use std::path::Path;
 
 // Collect staged and unstaged changes separately so the status panes can act on each side.
 pub fn get_filenames_diff_at_workdir(repo: &Repository) -> Result<UncommittedChanges, Error> {
+    if repo.workdir().is_none() {
+        return Err(Error::from_str(&errors::BARE_REPO_WORKDIR_OPERATION()));
+    }
+
     let mut options = StatusOptions::new();
-    options.include_untracked(true).exclude_submodules(true).show(git2::StatusShow::IndexAndWorkdir).renames_head_to_index(false).renames_index_to_workdir(false);
+    options.include_untracked(true).recurse_untracked_dirs(true).exclude_submodules(true).show(git2::StatusShow::IndexAndWorkdir).renames_head_to_index(false).renames_index_to_workdir(false);
 
     let statuses = repo.statuses(Some(&mut options))?;
     let mut changes = UncommittedChanges::default();
-    let workdir = repo.workdir().expect("Bare repo not supported");
     let submodules = repo.submodules().unwrap_or_default();
     let submodule_paths = submodules.iter().map(|entry| entry.path().to_path_buf()).collect::<Vec<_>>();
 
@@ -22,44 +28,7 @@ pub fn get_filenames_diff_at_workdir(repo: &Repository) -> Result<UncommittedCha
             continue;
         }
 
-        let full_path = workdir.join(rel_path);
-
-        // Directory statuses are expanded so the UI can show actionable file rows.
-        let files = if full_path.is_dir() { collect_files_for_status(repo, workdir, rel_path) } else { vec![rel_path.to_string()] };
-
-        for file in files {
-            if is_submodule_status_path(&file, &submodule_paths) {
-                continue;
-            }
-
-            // Query each file after expansion to avoid applying directory status to children.
-            let file_status = repo.status_file(Path::new(&file))?;
-
-            if file_status.is_conflicted() {
-                push_unique(&mut changes.conflicts, file.clone());
-                continue;
-            }
-
-            if file_status.is_index_modified() {
-                changes.staged.modified.push(file.clone());
-            }
-            if file_status.is_index_new() {
-                changes.staged.added.push(file.clone());
-            }
-            if file_status.is_index_deleted() {
-                changes.staged.deleted.push(file.clone());
-            }
-
-            if file_status.is_wt_modified() {
-                changes.unstaged.modified.push(file.clone());
-            }
-            if file_status.is_wt_new() {
-                changes.unstaged.added.push(file.clone());
-            }
-            if file_status.is_wt_deleted() {
-                changes.unstaged.deleted.push(file.clone());
-            }
-        }
+        apply_file_status(rel_path, entry.status(), &mut changes);
     }
 
     if let Ok(index) = repo.index()
@@ -86,6 +55,41 @@ pub fn get_filenames_diff_at_workdir(repo: &Repository) -> Result<UncommittedCha
     changes.is_clean = !changes.is_staged && !changes.is_unstaged && !changes.has_conflicts;
 
     Ok(changes)
+}
+
+pub fn get_uncommitted_changes(repo: &Repository) -> Result<Option<UncommittedChanges>, Error> {
+    if repo.is_bare() || repo.workdir().is_none() {
+        return Ok(None);
+    }
+
+    get_filenames_diff_at_workdir(repo).map(Some)
+}
+
+fn apply_file_status(file: &str, file_status: Status, changes: &mut UncommittedChanges) {
+    if file_status.is_conflicted() {
+        push_unique(&mut changes.conflicts, file.to_string());
+        return;
+    }
+
+    if file_status.is_index_modified() {
+        changes.staged.modified.push(file.to_string());
+    }
+    if file_status.is_index_new() {
+        changes.staged.added.push(file.to_string());
+    }
+    if file_status.is_index_deleted() {
+        changes.staged.deleted.push(file.to_string());
+    }
+
+    if file_status.is_wt_modified() {
+        changes.unstaged.modified.push(file.to_string());
+    }
+    if file_status.is_wt_new() {
+        changes.unstaged.added.push(file.to_string());
+    }
+    if file_status.is_wt_deleted() {
+        changes.unstaged.deleted.push(file.to_string());
+    }
 }
 
 fn add_submodule_pointer_changes(repo: &Repository, submodules: &[Submodule<'_>], changes: &mut UncommittedChanges) {
@@ -139,42 +143,6 @@ fn push_unique(paths: &mut Vec<String>, path: String) {
     if !paths.iter().any(|existing| existing == &path) {
         paths.push(path);
     }
-}
-
-fn collect_files_for_status(repo: &Repository, workdir: &Path, rel_path: &str) -> Vec<String> {
-    let full_path = workdir.join(rel_path);
-
-    if full_path.exists() {
-        if full_path.is_file() {
-            return vec![rel_path.to_string()];
-        } else if full_path.is_dir() {
-            let mut result = Vec::new();
-            if let Ok(entries) = std::fs::read_dir(&full_path) {
-                for entry in entries.flatten() {
-                    let path = entry.path();
-                    let child_rel = match path.strip_prefix(workdir) {
-                        Ok(p) => p.to_string_lossy().to_string(),
-                        Err(_) => continue,
-                    };
-
-                    // Respect gitignore while recursively expanding untracked directories.
-                    if repo.status_should_ignore(Path::new(&child_rel)).unwrap_or(false) {
-                        continue;
-                    }
-
-                    if path.is_file() {
-                        result.push(child_rel);
-                    } else if path.is_dir() {
-                        result.extend(collect_files_for_status(repo, workdir, &child_rel));
-                    }
-                }
-            }
-            return result;
-        }
-    }
-
-    // Deleted paths no longer exist on disk, but git still reports them by relative path.
-    vec![rel_path.to_string()]
 }
 
 // List files changed by a commit compared with its first parent.

--- a/src/git/queries/helpers.rs
+++ b/src/git/queries/helpers.rs
@@ -18,6 +18,12 @@ pub struct UncommittedChanges {
     pub has_conflicts: bool,    // True when the index has unresolved conflicts.
 }
 
+impl UncommittedChanges {
+    pub fn clean() -> Self {
+        Self { is_clean: true, ..Default::default() }
+    }
+}
+
 // File buckets are kept separate so status actions can address a stable row group.
 #[derive(Debug, Default, Clone)]
 pub struct FileChanges {

--- a/src/git/queries/worktrees.rs
+++ b/src/git/queries/worktrees.rs
@@ -25,6 +25,10 @@ fn repo_head(repo: &Repository) -> Option<git2::Oid> {
 }
 
 fn main_worktree_path(repo: &Repository) -> Option<PathBuf> {
+    if repo.is_bare() {
+        return None;
+    }
+
     repo.commondir().parent().map(Path::to_path_buf)
 }
 

--- a/src/helpers/keymap.rs
+++ b/src/helpers/keymap.rs
@@ -119,6 +119,41 @@ pub enum Command {
     ReloadAllBranches,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum RepoCapability {
+    History,
+    Worktree,
+}
+
+impl Command {
+    pub(crate) fn required_capability(&self) -> RepoCapability {
+        match self {
+            Self::Drop
+            | Self::Pop
+            | Self::Stash
+            | Self::Checkout
+            | Self::HardReset
+            | Self::MixedReset
+            | Self::Unstage
+            | Self::Stage
+            | Self::Commit
+            | Self::Cherrypick
+            | Self::Revert
+            | Self::Rebase
+            | Self::Merge
+            | Self::ContinueOperation
+            | Self::AbortOperation => RepoCapability::Worktree,
+            _ => RepoCapability::History,
+        }
+    }
+}
+
+impl RepoCapability {
+    pub(crate) fn requires_worktree(self) -> bool {
+        matches!(self, Self::Worktree)
+    }
+}
+
 pub type ModeKeymap = IndexMap<KeyBinding, Command>;
 pub type Keymaps = IndexMap<InputMode, ModeKeymap>;
 

--- a/src/helpers/localisation.rs
+++ b/src/helpers/localisation.rs
@@ -1826,6 +1826,9 @@ pub mod errors {
     pub fn CHECKOUT() -> &'static str {
         tr("Checkout failed")
     }
+    pub fn BARE_REPO_WORKDIR_OPERATION() -> &'static str {
+        tr("This operation requires a working tree")
+    }
     pub fn CHERRYPICK() -> &'static str {
         tr("Cherry-pick failed")
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,8 +37,10 @@ fn main() -> io::Result<()> {
         reset_saved_config()?;
     }
 
+    let mut app = App::default();
+
     let mut terminal = ratatui::init();
-    let app_result = App::default().run(&mut terminal);
+    let app_result = app.run(&mut terminal);
     ratatui::restore();
     app_result
 }

--- a/src/tests/app/input/events.rs
+++ b/src/tests/app/input/events.rs
@@ -1,7 +1,7 @@
 use super::*;
 use crate::{
     app::{
-        app::{ContextMenuAction, SettingsSelection, SettingsSelectionKind, SettingsTab},
+        app::{ContextMenuAction, SettingsSelection, SettingsSelectionKind, SettingsTab, WorktreeState},
         state::defaults::ViewerMode,
         state::layout::Layout,
     },
@@ -252,6 +252,23 @@ fn graph_context_menu_includes_fetch_and_push_when_repo_is_loaded() {
     let labels = context_menu_labels(&app);
     assert!(labels.iter().any(|label| label == "Fetch"), "{labels:?}");
     assert!(labels.iter().any(|label| label == "Push"), "{labels:?}");
+}
+
+#[test]
+fn bare_repo_context_menu_disables_workdir_commands() {
+    let (_path, repo) = temp_repo("bare-context-menu");
+    let mut app = graph_app();
+    app.repo = Some(Rc::new(repo));
+    app.worktree_state = WorktreeState::Unavailable;
+    app.graph_scroll.set(2);
+
+    app.handle_mouse_event(right_down(1, 3));
+
+    let items = &app.context_menu.as_ref().unwrap().items;
+    let checkout = items.iter().find(|item| item.label == "Checkout").unwrap();
+    let fetch = items.iter().find(|item| item.label == "Fetch").unwrap();
+    assert!(!checkout.enabled);
+    assert!(fetch.enabled);
 }
 
 #[test]

--- a/src/tests/app/input/git.rs
+++ b/src/tests/app/input/git.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::app::app::WorktreeState;
 use crate::core::chunk::NONE;
 use crate::core::reflogs::HeadReflogAliasEntry;
 use crate::git::actions::merging::{MergeOutcome, start_merge};
@@ -144,6 +145,21 @@ fn file_search_modal_does_not_open_from_splash_or_settings() {
     let mut settings = App { repo: Some(repo), viewport: Viewport::Settings, focus: Focus::Viewport, ..Default::default() };
     settings.on_find_file();
     assert_eq!(settings.focus, Focus::Viewport);
+}
+
+#[test]
+fn unavailable_worktree_blocks_worktree_commands_before_dispatch() {
+    let mut app = App { worktree_state: WorktreeState::Unavailable, viewport: Viewport::Graph, focus: Focus::Viewport, ..Default::default() };
+
+    for command in [Command::Checkout, Command::HardReset, Command::Stage, Command::Commit, Command::Cherrypick, Command::Revert, Command::Rebase, Command::Merge] {
+        app.focus = Focus::Viewport;
+        app.modal_error_message.clear();
+
+        app.dispatch_command(&command);
+
+        assert_eq!(app.focus, Focus::ModalError);
+        assert_eq!(app.modal_error_message, crate::helpers::localisation::errors::BARE_REPO_WORKDIR_OPERATION());
+    }
 }
 
 #[test]

--- a/src/tests/app/state/app.rs
+++ b/src/tests/app/state/app.rs
@@ -64,6 +64,24 @@ fn commit_index(repo: &Repository, message: &str) -> git2::Oid {
     repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &parents).unwrap()
 }
 
+fn init_bare_repo_at(path: &Path) -> Repository {
+    fs::create_dir_all(path).unwrap();
+    let repo = Repository::init_bare(path).unwrap();
+
+    let tree_oid = {
+        let blob = repo.blob(b"initial\n").unwrap();
+        let mut builder = repo.treebuilder(None).unwrap();
+        builder.insert("file.txt", blob, 0o100644).unwrap();
+        builder.write().unwrap()
+    };
+    let tree = repo.find_tree(tree_oid).unwrap();
+    let sig = Signature::now("Test User", "test@example.com").unwrap();
+    repo.commit(Some("refs/heads/main"), &sig, &sig, "initial", &tree, &[]).unwrap();
+    repo.set_head("refs/heads/main").unwrap();
+    drop(tree);
+    repo
+}
+
 fn init_repo_at(path: &Path) -> Repository {
     fs::create_dir_all(path).unwrap();
     let repo = Repository::init(path).unwrap();
@@ -384,4 +402,81 @@ fn pane_window_request_reuses_cached_window_that_covers_range() {
         },
         other => panic!("expected pane window request, got {other:?}"),
     }
+}
+
+#[test]
+fn bare_repo_reload_reaches_graph_without_workdir_status_error() {
+    let dir = TestDir::new("bare-reload");
+    let bare_path = dir.path.join("repo.git");
+    drop(init_bare_repo_at(&bare_path));
+
+    let mut app = App { name: "stale".to_string(), email: "stale".to_string(), ..Default::default() };
+    app.layout_config.is_status = false;
+    app.reload(Some(bare_path.display().to_string()));
+    let repo = app.repo.clone().unwrap();
+
+    for _ in 0..100 {
+        app.sync(&repo);
+        if app.is_uncommitted_loaded {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(10));
+    }
+
+    assert!(repo.is_bare());
+    assert_eq!(app.viewport, Viewport::Graph);
+    assert!(app.is_uncommitted_loaded);
+    assert!(app.modal_error_message.is_empty());
+    assert!(app.uncommitted.is_clean);
+    assert!(app.worktrees.entries.is_empty());
+    assert!(app.submodules.entries.is_empty());
+
+    app.on_narrow_scope();
+    assert_eq!(app.focus, Focus::Viewport);
+    assert!(!app.layout_config.is_status);
+
+    stop_graph_service(&mut app);
+}
+
+#[test]
+fn bare_repo_reload_keeps_configured_identity() {
+    let dir = TestDir::new("bare-reload-identity");
+    let bare_path = dir.path.join("repo.git");
+    let repo = init_bare_repo_at(&bare_path);
+    {
+        let mut config = repo.config().unwrap();
+        config.set_str("user.name", "Bare User").unwrap();
+        config.set_str("user.email", "bare@example.com").unwrap();
+    }
+    drop(repo);
+
+    let mut app = App::default();
+    app.layout_config.is_status = false;
+    app.reload(Some(bare_path.display().to_string()));
+
+    assert_eq!(app.name, "Bare User");
+    assert_eq!(app.email, "bare@example.com");
+
+    stop_graph_service(&mut app);
+}
+
+#[test]
+fn reload_refreshes_worktree_state_for_new_repository() {
+    let dir = TestDir::new("worktree-state-refresh");
+    let bare_path = dir.path.join("repo.git");
+    drop(init_bare_repo_at(&bare_path));
+    let worktree_path = dir.path.join("repo");
+    drop(init_repo_at(&worktree_path));
+
+    let mut app = App::default();
+    app.reload(Some(bare_path.display().to_string()));
+    assert_eq!(app.worktree_state, WorktreeState::Unavailable);
+    stop_graph_service(&mut app);
+
+    app.reload(Some(worktree_path.display().to_string()));
+
+    assert_eq!(app.worktree_state, WorktreeState::Available);
+    assert!(app.command_is_available(&Command::Checkout));
+
+    stop_graph_service(&mut app);
 }

--- a/src/tests/git/queries/diffs.rs
+++ b/src/tests/git/queries/diffs.rs
@@ -43,6 +43,14 @@ fn temp_repo(name: &str) -> (PathBuf, Repository) {
     (path, repo)
 }
 
+fn temp_bare_repo(name: &str) -> (PathBuf, Repository) {
+    let id = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+    let path = std::env::temp_dir().join(format!("guitar-diff-{name}-{id}.git"));
+    fs::create_dir_all(&path).unwrap();
+    let repo = Repository::init_bare(&path).unwrap();
+    (path, repo)
+}
+
 fn write(path: &Path, file: &str, content: &str) {
     fs::write(path.join(file), content).unwrap();
 }
@@ -119,10 +127,11 @@ fn workdir_diff_marks_conflicted_paths() {
     let (path, repo) = temp_repo("conflict");
     write(&path, "file.txt", "base\n");
     commit(&repo, "file.txt", "base");
+    let default_branch = repo.head().unwrap().shorthand().unwrap().to_string();
     checkout_new_branch(&repo, "feature");
     write(&path, "file.txt", "feature\n");
     commit(&repo, "file.txt", "feature");
-    checkout_branch(&repo, "master");
+    checkout_branch(&repo, &default_branch);
     write(&path, "file.txt", "main\n");
     let main = commit(&repo, "file.txt", "main");
     checkout_branch(&repo, "feature");
@@ -147,6 +156,28 @@ fn workdir_diff_marks_conflicted_paths() {
 }
 
 #[test]
+fn workdir_diff_returns_error_for_bare_repo() {
+    let (path, repo) = temp_bare_repo("bare");
+
+    let error = get_filenames_diff_at_workdir(&repo).unwrap_err();
+
+    assert_eq!(error.message(), crate::helpers::localisation::errors::BARE_REPO_WORKDIR_OPERATION());
+
+    let _ = fs::remove_dir_all(path);
+}
+
+#[test]
+fn uncommitted_changes_are_absent_for_bare_repo() {
+    let (path, repo) = temp_bare_repo("bare-uncommitted");
+
+    let changes = get_uncommitted_changes(&repo).unwrap();
+
+    assert!(changes.is_none());
+
+    let _ = fs::remove_dir_all(path);
+}
+
+#[test]
 fn workdir_file_diff_emits_untracked_file_contents_as_added_lines() {
     let (path, repo) = temp_repo("untracked-added-lines");
     write(&path, "tracked.txt", "base\n");
@@ -159,6 +190,26 @@ fn workdir_file_diff_emits_untracked_file_contents_as_added_lines() {
     assert!(!content_lines.is_empty());
     assert_eq!(content_lines.iter().map(|line| line.origin).collect::<Vec<_>>(), vec!['+', '+']);
     assert_eq!(content_lines.iter().map(|line| line.content.as_str()).collect::<Vec<_>>(), vec!["alpha\n", "beta\n"]);
+
+    let _ = fs::remove_dir_all(path);
+}
+
+#[test]
+fn workdir_diff_lists_files_inside_untracked_directories() {
+    let (path, repo) = temp_repo("untracked-directory-files");
+    write(&path, "tracked.txt", "base\n");
+    commit(&repo, "tracked.txt", "initial");
+    fs::create_dir_all(path.join("scratch/nested")).unwrap();
+    write(&path, "scratch/nested/one.txt", "one\n");
+    write(&path, "scratch/nested/two.txt", "two\n");
+
+    let changes = get_filenames_diff_at_workdir(&repo).unwrap();
+
+    assert_eq!(changes.unstaged.added.len(), 2);
+    assert!(changes.unstaged.added.iter().any(|path| path == "scratch/nested/one.txt"));
+    assert!(changes.unstaged.added.iter().any(|path| path == "scratch/nested/two.txt"));
+    assert!(changes.is_unstaged);
+    assert!(!changes.is_clean);
 
     let _ = fs::remove_dir_all(path);
 }


### PR DESCRIPTION
## Summary

This lets `guitar` open bare repositories for history browsing without a working tree. Repository loads now derive worktree capability from the currently opened `git2::Repository`, so reloading or switching repositories cannot leave stale bare/worktree state behind.

The same change keeps workdir status collection on libgit2's recursive status entries, rather than expanding untracked directories through filesystem paths and re-querying each child. That avoids path re-resolution problems on case-insensitive filesystems when a repo contains case-colliding filenames from another platform.

A better way to do this in the future would be to move toward more of a state machine than a bunch of bools.

## Details

- Detect missing worktrees from the opened repository instead of a sticky app-level startup mode.
- Model command availability through `Command::required_capability()` and current repository worktree support.
- Treat repositories without a worktree as having no workdir status result at the query boundary, then show an empty uncommitted-change view.
- Keep Git identity loading independent of worktree availability.
- Block worktree-mutating actions when the current repository has no worktree.
- Preserve conflict and submodule status handling while using recursive status entries for untracked directories.

## Details

- Detect bare repositories from the opened repository instead of a sticky app-level mode flag.
- Model command availability through `Command::required_capability()` and current repository worktree support.
- Treat repositories without a worktree as having no uncommitted-change result at the query boundary, so graph/history browsing can load cleanly.
- Keep Git identity loading independent of worktree availability.
- Block worktree-mutating actions when the current repository has no worktree.
- Preserve conflict and submodule status handling while using recursive status entries for untracked directories.

## Tests

- `cargo test bare_repo -- --nocapture`
- `cargo test unavailable_worktree_blocks_worktree_commands_before_dispatch -- --nocapture`
- `cargo test reload_refreshes_worktree_state_for_new_repository -- --nocapture`
- `cargo test workdir_diff -- --nocapture`

