### PR TITLE
[02/08] replace commit identity storage with gix-backed aliases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,6 +63,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "atomic"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -153,6 +162,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -171,6 +191,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -181,9 +207,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.64"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dad887fd958be91b5098c0248def011f4523ab786cd411be668777e55063501f"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -254,6 +280,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "clru"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "197fd99cb113a8d5d9b6376f3aa817f32c1078f2343b714fff7d2ca44fdf67d5"
+dependencies = [
+ "hashbrown 0.16.1",
+]
+
+[[package]]
 name = "colored"
 version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -322,10 +357,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
@@ -394,7 +444,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -405,7 +455,53 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "dashmap"
+version = "6.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
+dependencies = [
+ "cfg-if",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -419,9 +515,6 @@ name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
-dependencies = [
- "powerfmt",
-]
 
 [[package]]
 name = "derive_more"
@@ -442,7 +535,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -484,7 +577,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -509,7 +602,7 @@ checksum = "9556bc800956545d6420a640173e5ba7dfa82f38d3ea5a167eb555bc69ac3323"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -520,6 +613,12 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "either"
@@ -580,7 +679,7 @@ checksum = "a63e0ade4c53b40220614b8fc2a0a0ce21975941b553081521a195c848b2e9c2"
 dependencies = [
  "autocfg",
  "const-fnv1a-hash",
- "iddqd",
+ "iddqd 0.3.18",
  "impls",
 ]
 
@@ -710,6 +809,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +833,16 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "winapi",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -830,16 +949,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
  "r-efi 6.0.0",
  "rand_core 0.10.1",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -864,6 +981,828 @@ dependencies = [
 ]
 
 [[package]]
+name = "gix"
+version = "0.78.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3428a03ace494ae40308bd3df0b37e7eb7403e24389f27abdff30abf2b5adf17"
+dependencies = [
+ "gix-actor",
+ "gix-attributes",
+ "gix-command",
+ "gix-commitgraph",
+ "gix-config",
+ "gix-credentials",
+ "gix-date",
+ "gix-diff",
+ "gix-dir",
+ "gix-discover",
+ "gix-error",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-ignore",
+ "gix-index",
+ "gix-lock",
+ "gix-negotiate",
+ "gix-object",
+ "gix-odb",
+ "gix-pack",
+ "gix-path",
+ "gix-pathspec",
+ "gix-prompt",
+ "gix-protocol",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revision",
+ "gix-revwalk",
+ "gix-sec",
+ "gix-shallow",
+ "gix-status",
+ "gix-submodule",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-transport",
+ "gix-traverse",
+ "gix-url",
+ "gix-utils",
+ "gix-validate",
+ "gix-worktree",
+ "gix-worktree-state",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-actor"
+version = "0.38.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b50ce5433eaa46187349e59089eea71b0397caa71991b2fa3e124120426d7d15"
+dependencies = [
+ "bstr",
+ "gix-date",
+ "gix-utils",
+ "itoa",
+ "thiserror 2.0.18",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-attributes"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e72da5a1c35c9a129be0c60ab9968779981ca50835dd98650ecd8b0ea4d721e"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "kstring",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-bitmap"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d982fc7ef0608e669851d0d2a6141dae74c60d5a27e8daa451f2a4857bbf41e2"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-chunk"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e516efaac951ed21115b11d5514b120c26ccb493d0c0b9ea6cc10edf4fdf44"
+dependencies = [
+ "gix-error",
+]
+
+[[package]]
+name = "gix-command"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2962172c6f78731e2b7773bf762f7b8d1746a342a4c0a8914a612206e1295953"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "shell-words",
+]
+
+[[package]]
+name = "gix-commitgraph"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0dda2e4d5a61d4a16a780f61f2b7e9406ad1f8da97c35c09ef501f3fdf74de0"
+dependencies = [
+ "bstr",
+ "gix-chunk",
+ "gix-error",
+ "gix-hash",
+ "memmap2",
+]
+
+[[package]]
+name = "gix-config"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a153dd4f5789fdf242e19e3f7105f2a114df198570225976fe4a108bac9dee4"
+dependencies = [
+ "bstr",
+ "gix-config-value",
+ "gix-features",
+ "gix-glob",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "memchr",
+ "smallvec",
+ "thiserror 2.0.18",
+ "unicode-bom",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-config-value"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4378c53ec3db049919edf91ff76f56f28886a8b4b4a5a9dc633108d84afc3675"
+dependencies = [
+ "bitflags 2.13.0",
+ "bstr",
+ "gix-path",
+ "libc",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-credentials"
+version = "0.35.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6ef04ac6b0b9cb75b02afaab4045eafb7b59be41815fbfaaa184a2280af2146"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-config-value",
+ "gix-date",
+ "gix-path",
+ "gix-prompt",
+ "gix-sec",
+ "gix-trace",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-date"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12553b32d1da25671f31c0b084bf1e5cb6d5ef529254d04ec33cdc890bd7f687"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "itoa",
+ "jiff",
+ "smallvec",
+]
+
+[[package]]
+name = "gix-diff"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26bcd367b2c5dbf6bec9ce02ca59eab179fc82cf39f15ec83549ee25c255c99f"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-command",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-tempfile",
+ "gix-trace",
+ "gix-traverse",
+ "gix-worktree",
+ "imara-diff",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-dir"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "004129e2c93798141d68ff08cb7f1b3d909c0212747fb8b05c8989635ba90a4e"
+dependencies = [
+ "bstr",
+ "gix-discover",
+ "gix-fs",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-trace",
+ "gix-utils",
+ "gix-worktree",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-discover"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "950b027b861c6863ddf1b075672ec1ef2006b95c4d12284fc1ec4cdb1ab6639e"
+dependencies = [
+ "bstr",
+ "dunce",
+ "gix-fs",
+ "gix-path",
+ "gix-ref",
+ "gix-sec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-error"
+version = "0.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dffc9ca4dfa4f519a3d2cf1c038919160544923577ac60f45bcb602a24d82c6"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-features"
+version = "0.46.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "752493cd4b1d5eaaa0138a7493f65c96863fefa990fc021e0e519579e389ab20"
+dependencies = [
+ "crc32fast",
+ "gix-path",
+ "gix-trace",
+ "gix-utils",
+ "libc",
+ "once_cell",
+ "prodash",
+ "thiserror 2.0.18",
+ "walkdir",
+ "zlib-rs",
+]
+
+[[package]]
+name = "gix-filter"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7240442915cdd74e1f889566695ce0d0c23c7185b13318a1232ce646af0d18ad"
+dependencies = [
+ "bstr",
+ "encoding_rs",
+ "gix-attributes",
+ "gix-command",
+ "gix-hash",
+ "gix-object",
+ "gix-packetline",
+ "gix-path",
+ "gix-quote",
+ "gix-trace",
+ "gix-utils",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-fs"
+version = "0.19.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a964b4aec683eb0bacb87533defa80805bb4768056371a47ab38b00a2d377b72"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "gix-features",
+ "gix-path",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-glob"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b03e6cd88cc0dc1eafa1fddac0fb719e4e74b6ea58dd016e71125fde4a326bee"
+dependencies = [
+ "bitflags 2.13.0",
+ "bstr",
+ "gix-features",
+ "gix-path",
+]
+
+[[package]]
+name = "gix-hash"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8ced05d2d7b13bff08b2f7eb4e47cfeaf00b974c2ddce08377c4fe1f706b3eb"
+dependencies = [
+ "faster-hex",
+ "gix-features",
+ "sha1-checked",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-hashtable"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f1eecdd006390cbed81f105417dbf82a6fe40842022006550f2e32484101da"
+dependencies = [
+ "gix-hash",
+ "hashbrown 0.16.1",
+ "parking_lot",
+]
+
+[[package]]
+name = "gix-ignore"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f915dcf6911e3027537166d34e13f0fe101ed12225178d2ae29cd1272cff26"
+dependencies = [
+ "bstr",
+ "gix-glob",
+ "gix-path",
+ "gix-trace",
+ "unicode-bom",
+]
+
+[[package]]
+name = "gix-index"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31c6b3664efe5916c539c50e610f9958f2993faf8e29fa5a40fb80b6ac8486a"
+dependencies = [
+ "bitflags 2.13.0",
+ "bstr",
+ "filetime",
+ "fnv",
+ "gix-bitmap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-traverse",
+ "gix-utils",
+ "gix-validate",
+ "hashbrown 0.16.1",
+ "itoa",
+ "libc",
+ "memmap2",
+ "rustix",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-lock"
+version = "21.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054fbd0989700c69dc5aa80bc66944f05df1e15aa7391a9e42aca7366337905f"
+dependencies = [
+ "gix-tempfile",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-negotiate"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00dff6d49869f16b8900da7c27b886a45cbf641b1e45aab355d012afe4266b7f"
+dependencies = [
+ "bitflags 2.13.0",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-object"
+version = "0.55.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d3f705c977d90ace597049252ae1d7fec907edc0fa7616cc91bf5508d0f4006"
+dependencies = [
+ "bstr",
+ "gix-actor",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-path",
+ "gix-utils",
+ "gix-validate",
+ "itoa",
+ "smallvec",
+ "thiserror 2.0.18",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-odb"
+version = "0.75.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d59882d2fdab5e609b0c452a6ef9a3bd12ef6b694be4f82ab8f126ad0969864"
+dependencies = [
+ "arc-swap",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-pack",
+ "gix-path",
+ "gix-quote",
+ "parking_lot",
+ "tempfile",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pack"
+version = "0.65.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c44db57ebbbeaad9972c2a60662142660427a1f0a7529314d53fefb4fedad24"
+dependencies = [
+ "clru",
+ "gix-chunk",
+ "gix-error",
+ "gix-features",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "memmap2",
+ "parking_lot",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-packetline"
+version = "0.21.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b217dd0ee0c4021ecf169a4a519b1b4f80d15e3f3765f3dc466223dc0ac891d7"
+dependencies = [
+ "bstr",
+ "faster-hex",
+ "gix-trace",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-path"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8fd1fe596dc393b538e1d5492c5585971a9311475b3255f7b889023df208476"
+dependencies = [
+ "bstr",
+ "gix-trace",
+ "gix-validate",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-pathspec"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f4cc23f55ca7c190bf243f1a4e2139d4522022f724fb0dfc06c93f65a01ef6"
+dependencies = [
+ "bitflags 2.13.0",
+ "bstr",
+ "gix-attributes",
+ "gix-config-value",
+ "gix-glob",
+ "gix-path",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-prompt"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4806f1ebf969cd54d178ccd975911ef1829aeccea0b27630e63c9d26c8347d7f"
+dependencies = [
+ "gix-command",
+ "gix-config-value",
+ "parking_lot",
+ "rustix",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-protocol"
+version = "0.56.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54f20837b0c70b65f6ac77886be033de3b69d5879f99128b47c42665ab0a17c2"
+dependencies = [
+ "bstr",
+ "gix-credentials",
+ "gix-date",
+ "gix-features",
+ "gix-hash",
+ "gix-lock",
+ "gix-negotiate",
+ "gix-object",
+ "gix-ref",
+ "gix-refspec",
+ "gix-revwalk",
+ "gix-shallow",
+ "gix-trace",
+ "gix-transport",
+ "gix-utils",
+ "maybe-async",
+ "thiserror 2.0.18",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-quote"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96fc2ff2ec8cc0c92807f02eab1f00eb02619fc2810d13dc42679492fcc36757"
+dependencies = [
+ "bstr",
+ "gix-utils",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-ref"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf780dcd9ac99fd3fcfc8523479a0e2ffd55f5e0be63e5e3248fb7e46cff966"
+dependencies = [
+ "gix-actor",
+ "gix-features",
+ "gix-fs",
+ "gix-hash",
+ "gix-lock",
+ "gix-object",
+ "gix-path",
+ "gix-tempfile",
+ "gix-utils",
+ "gix-validate",
+ "memmap2",
+ "thiserror 2.0.18",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "gix-refspec"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60ce400a770a7952e45267803192cc2d1fe0afa08e2c08dde32e04c7908c6e61"
+dependencies = [
+ "bstr",
+ "gix-error",
+ "gix-glob",
+ "gix-hash",
+ "gix-revision",
+ "gix-validate",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-revision"
+version = "0.40.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c719cf7d669439e1fca735bd1c4de54d43c5d30e8883fd6063c4924b213d70c9"
+dependencies = [
+ "bitflags 2.13.0",
+ "bstr",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "gix-trace",
+]
+
+[[package]]
+name = "gix-revwalk"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a50b30aa0c6e6de43c723359c5809a96275a3aa92d323ef7f58b1cdd60f16"
+dependencies = [
+ "gix-commitgraph",
+ "gix-date",
+ "gix-error",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-sec"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "283f4a746c9bde8550be63e6f961ff4651f412ca12666e8f5615f39464960ab9"
+dependencies = [
+ "bitflags 2.13.0",
+ "gix-path",
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "gix-shallow"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189386b5da5285216cc0ede89eff5a943d5261fc794241ee6ec5360b77df15ad"
+dependencies = [
+ "bstr",
+ "gix-hash",
+ "gix-lock",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-status"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c994dbca7f038cfcde6337673523bab6e6b4f544b5046f5120a02bdeafff33"
+dependencies = [
+ "bstr",
+ "filetime",
+ "gix-diff",
+ "gix-dir",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-hash",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-pathspec",
+ "gix-worktree",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-submodule"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db1840fe723c6264ee596e5a179e1b9a2df59351f09bae9cea570a472a790bc0"
+dependencies = [
+ "bstr",
+ "gix-config",
+ "gix-path",
+ "gix-pathspec",
+ "gix-refspec",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-tempfile"
+version = "21.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d22227f6b203f511ff451c33c89899e87e4f571fc596b06f68e6e613a6508528"
+dependencies = [
+ "dashmap",
+ "gix-fs",
+ "libc",
+ "parking_lot",
+ "tempfile",
+]
+
+[[package]]
+name = "gix-trace"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44dc45eae785c0eb14173e0f152e6e224dcf4d45b6a6999a3aed22af541ad678"
+
+[[package]]
+name = "gix-transport"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de1064c7ffa5a915014a6a5b71fbc5299462ae655348bed23e083b4a735076c3"
+dependencies = [
+ "bstr",
+ "gix-command",
+ "gix-features",
+ "gix-packetline",
+ "gix-quote",
+ "gix-sec",
+ "gix-url",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-traverse"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37f8b53b4c56b01c43a4491c4edfe2ce66c654eb86232205172ceb1650d21c55"
+dependencies = [
+ "bitflags 2.13.0",
+ "gix-commitgraph",
+ "gix-date",
+ "gix-hash",
+ "gix-hashtable",
+ "gix-object",
+ "gix-revwalk",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-url"
+version = "0.35.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a61ead12e33fa52ae92b207ee27554f646a8e7a3dad8b78da1582ec91eda0a6"
+dependencies = [
+ "bstr",
+ "gix-path",
+ "percent-encoding",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-utils"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66c50966184123caf580ffa64e28031a878597f1c7fceb8fe19566c38eb1b771"
+dependencies = [
+ "bstr",
+ "fastrand",
+ "unicode-normalization",
+]
+
+[[package]]
+name = "gix-validate"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bc6fc771c4063ba7cd2f47b91fb6076251c6a823b64b7fe7b8874b0fe4afae3"
+dependencies = [
+ "bstr",
+]
+
+[[package]]
+name = "gix-worktree"
+version = "0.47.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef2ad658586ec0039b03e96c664f08b7cb7a2b7cca6947a9c856c9ed59b807b1"
+dependencies = [
+ "bstr",
+ "gix-attributes",
+ "gix-fs",
+ "gix-glob",
+ "gix-hash",
+ "gix-ignore",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-validate",
+]
+
+[[package]]
+name = "gix-worktree-state"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9895abc7654cbd8e102d6a765d3bdfa1567fcd5d2849b8e3d3da6405d64913c9"
+dependencies = [
+ "bstr",
+ "gix-features",
+ "gix-filter",
+ "gix-fs",
+ "gix-index",
+ "gix-object",
+ "gix-path",
+ "gix-worktree",
+ "io-close",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "guitar"
 version = "1.0.4"
 dependencies = [
@@ -876,15 +1815,36 @@ dependencies = [
  "facet",
  "facet-json",
  "git2",
+ "gix",
+ "gix-worktree",
+ "gix-worktree-state",
+ "iddqd 0.4.5",
  "im",
  "indexmap",
  "miette",
  "rand 0.10.1",
  "ratatui",
+ "rustc-hash",
+ "smallvec",
  "tempfile",
  "toml",
  "walkdir",
 ]
+
+[[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
@@ -915,6 +1875,16 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -1036,12 +2006,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
-
-[[package]]
 name = "iddqd"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1052,6 +2016,18 @@ dependencies = [
  "foldhash 0.2.0",
  "hashbrown 0.16.1",
  "rustc-hash",
+]
+
+[[package]]
+name = "iddqd"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7cf7e72dd082126bd727c1f8bd2d5229c2780258c0b3c7bc33eaf0f4ea5f0fa"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1096,6 +2072,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "imara-diff"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17d34b7d42178945f775e84bc4c36dde7c1c6cdfea656d3354d009056f2bb3d2"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "impls"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,8 +2094,6 @@ checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
  "hashbrown 0.17.1",
- "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -1132,7 +2115,17 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "io-close"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cadcf447f06744f8ce713d2d6239bb5bde2c357a452397a9ed90c625da390bc"
+dependencies = [
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -1155,6 +2148,48 @@ name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
+
+[[package]]
+name = "jiff"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
+dependencies = [
+ "defmt",
+ "jiff-static",
+ "jiff-tzdb-platform",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+ "windows-link",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "jiff-tzdb"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c900ef84826f1338a557697dc8fc601df9ca9af4ac137c7fb61d4c6f2dfd3076"
+
+[[package]]
+name = "jiff-tzdb-platform"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875a5a69ac2bab1a891711cf5eccbec1ce0341ea805560dcd90b7a2e925132e8"
+dependencies = [
+ "jiff-tzdb",
+]
 
 [[package]]
 name = "jobserver"
@@ -1189,6 +2224,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kstring"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
+dependencies = [
+ "static_assertions",
+]
+
+[[package]]
 name = "lab"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1199,12 +2243,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
@@ -1305,9 +2343,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.32"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "lru"
@@ -1329,10 +2367,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "maybe-async"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "746873a384ad60adc5db74471dfaba74bd278afbdcfd81db93fafcdfc8b5ca0c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "memmem"
@@ -1376,7 +2434,7 @@ checksum = "db5b29714e950dbb20d5e6f74f9dcec4edbcc1067bb7f8ed198c097b8c1a818b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1449,7 +2507,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1545,7 +2603,7 @@ dependencies = [
  "by_address",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1607,7 +2665,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1660,7 +2718,7 @@ dependencies = [
  "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1691,6 +2749,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,13 +2773,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1725,10 +2804,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "quote"
-version = "1.0.45"
+name = "prodash"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
+checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
+dependencies = [
+ "parking_lot",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -1761,7 +2849,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "rand_core 0.10.1",
 ]
 
@@ -2036,20 +3124,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "serde_json"
-version = "1.0.150"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
-dependencies = [
- "itoa",
- "memchr",
- "serde",
- "serde_core",
- "zmij",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2062,6 +3137,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
+name = "sha1-checked"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89f599ac0c323ebb1c6082821a54962b839832b03984598375bff3975b804423"
+dependencies = [
+ "digest",
+ "sha1",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2071,6 +3167,12 @@ dependencies = [
  "cpufeatures 0.2.17",
  "digest",
 ]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
@@ -2173,7 +3275,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2210,9 +3312,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.117"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2227,7 +3329,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2237,7 +3339,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -2365,7 +3467,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2376,14 +3478,14 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
  "libc",
@@ -2396,9 +3498,9 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "tinystr"
@@ -2409,6 +3511,21 @@ dependencies = [
  "displaydoc",
  "zerovec",
 ]
+
+[[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
@@ -2422,7 +3539,7 @@ dependencies = [
  "toml_datetime",
  "toml_parser",
  "toml_writer",
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -2440,7 +3557,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -2462,6 +3579,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
+name = "unicode-bom"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eec5d1121208364f6793f7d2e222bf75a915c19557537745b195b253dd64217"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2472,6 +3595,15 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-segmentation"
@@ -2501,12 +3633,6 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsynn"
@@ -2550,7 +3676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "atomic",
- "getrandom 0.4.2",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -2598,16 +3724,7 @@ version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
- "wit-bindgen 0.57.1",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
-dependencies = [
- "wit-bindgen 0.51.0",
+ "wit-bindgen",
 ]
 
 [[package]]
@@ -2642,7 +3759,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
@@ -2653,40 +3770,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23939e44bb9a5d7576fa2b563dc2e136628f1224e88a8deed09e04858b77871f"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags 2.13.0",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
 ]
 
 [[package]]
@@ -2813,7 +3896,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2824,7 +3907,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2862,103 +3945,24 @@ dependencies = [
 
 [[package]]
 name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.117",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags 2.13.0",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
 
 [[package]]
 name = "writeable"
@@ -2985,7 +3989,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -3006,7 +4010,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
  "synstructure",
 ]
 
@@ -3040,11 +4044,11 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 2.0.118",
 ]
 
 [[package]]
-name = "zmij"
-version = "1.0.21"
+name = "zlib-rs"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+checksum = "977347db8caa080403f6b6b7c1cda9479a8e869316f7e13a59b19076a40f94e3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,11 +19,17 @@ encoding_rs = "0.8.35"
 facet = "0.43"
 facet-json = "0.43.2"
 git2 = "0.20.4"
+gix = { version = "0.78.0", default-features = false, features = ["basic", "status", "blocking-network-client", "worktree-mutation"] }
+gix-worktree = "0.47.0"
+gix-worktree-state = "0.25.0"
+iddqd = "0.4.5"
 im = "15.1.0"
 indexmap = "2.12.1"
 miette = { version = "7", features = ["fancy"] } # pretty diagnostics
 rand = "0.10"
 ratatui = "0.30.0"
+rustc-hash = "2.1.2"
+smallvec = "1.15.2"
 toml = "1.0.1"
 walkdir = "2.5.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ indexmap = "2.12.1"
 miette = { version = "7", features = ["fancy"] } # pretty diagnostics
 rand = "0.10"
 ratatui = "0.30.0"
+# FxHashSet backs gitoxide graph-walk seen sets introduced later in this stack.
 rustc-hash = "2.1.2"
 smallvec = "1.15.2"
 toml = "1.0.1"

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -650,9 +650,6 @@ pub struct App {
 
     // Main loop shutdown flag.
     pub is_exit: bool,
-
-    // When set, skip the first workdir status scan (bare repos, case-colliding paths).
-    pub skip_workdir_status: bool,
 }
 
 impl App {
@@ -671,7 +668,6 @@ impl App {
     }
 
     pub fn wait_until_graph_complete(&mut self, timeout: Duration) -> io::Result<usize> {
-        self.skip_workdir_status = true;
         let repo = self.repo.as_ref().ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "repository not loaded"))?.clone();
 
         let started = Instant::now();
@@ -1091,18 +1087,14 @@ impl App {
                         self.viewport = Viewport::Graph;
                     }
 
-                    if self.skip_workdir_status {
-                        self.uncommitted = UncommittedChanges::default();
-                    } else {
-                        match get_filenames_diff_at_workdir(repo) {
-                            Ok(uncommitted) => {
-                                self.uncommitted = uncommitted;
-                            },
-                            Err(error) => {
-                                self.uncommitted = UncommittedChanges::default();
-                                self.show_error(errors::with_error(errors::FILE_DIFF(), error));
-                            },
-                        }
+                    match get_filenames_diff_at_workdir(repo) {
+                        Ok(uncommitted) => {
+                            self.uncommitted = uncommitted;
+                        },
+                        Err(error) => {
+                            self.uncommitted = UncommittedChanges::default();
+                            self.show_error(errors::with_error(errors::FILE_DIFF(), error));
+                        },
                     }
                     self.is_uncommitted_loaded = true;
                 }

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -1251,7 +1251,7 @@ impl App {
             return None;
         }
 
-        self.oids.get_sorted_aliases().get(index).map(|&alias| GraphIndexIdentity { index, alias, oid: *self.oids.get_oid_by_alias(alias) })
+        self.oids.get_sorted_aliases().get(index).map(|&alias| GraphIndexIdentity { index, alias, oid: self.oids.get_git2_oid_by_alias(alias) })
     }
 
     pub(crate) fn graph_alias_at(&self, index: usize) -> Option<u32> {

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -650,9 +650,60 @@ pub struct App {
 
     // Main loop shutdown flag.
     pub is_exit: bool,
+
+    // When set, skip the first workdir status scan (bare repos, case-colliding paths).
+    pub skip_workdir_status: bool,
 }
 
 impl App {
+    pub fn shutdown_background_tasks(&mut self) {
+        self.graph_tx.take().into_iter().for_each(|tx| {
+            let _ = tx.send(GraphCommand::Shutdown);
+        });
+        self.graph_rx = None;
+
+        self.walker_cancel.take().into_iter().for_each(|cancel| {
+            cancel.store(true, std::sync::atomic::Ordering::SeqCst);
+        });
+        self.walker_handle.take().into_iter().for_each(|handle| {
+            let _ = handle.join();
+        });
+    }
+
+    pub fn wait_until_graph_complete(&mut self, timeout: Duration) -> io::Result<usize> {
+        self.skip_workdir_status = true;
+        let repo = self.repo.as_ref().ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "repository not loaded"))?.clone();
+
+        let started = Instant::now();
+        loop {
+            self.sync(&repo);
+
+            let result = match (self.modal_error_message.as_str(), self.graph.is_complete, self.graph_rx.is_none(), started.elapsed() >= timeout) {
+                (message, _, _, _) if !message.is_empty() => Some(Err(io::Error::other(message.to_owned()))),
+                (_, true, _, _) => Some(Ok(self.graph_commit_count())),
+                (_, false, true, _) => Some(Err(io::Error::new(io::ErrorKind::BrokenPipe, "graph worker disconnected before completion"))),
+                (_, false, false, true) => Some(Err(io::Error::new(io::ErrorKind::TimedOut, "timed out waiting for graph completion"))),
+                (_, false, false, false) => None,
+            };
+
+            if let Some(result) = result {
+                break result;
+            }
+
+            std::thread::sleep(Duration::from_millis(25));
+        }
+    }
+
+    pub fn bootstrap(&mut self, repo_path: Option<String>) {
+        self.load_language_config();
+        self.load_recent();
+        self.load_layout();
+        self.load_theme_config();
+        self.load_symbol_theme_config();
+        self.load_keymap();
+        self.reload(repo_path);
+    }
+
     pub fn run(&mut self, terminal: &mut DefaultTerminal) -> io::Result<()> {
         // Ask supported terminals to distinguish Esc from modified key sequences.
         enable_raw_mode()?;
@@ -665,13 +716,7 @@ impl App {
 
         let run_result = (|| {
             // Load persisted state before the first repository scan.
-            self.load_language_config();
-            self.load_recent();
-            self.load_layout();
-            self.load_theme_config();
-            self.load_symbol_theme_config();
-            self.load_keymap();
-            self.reload(None);
+            self.bootstrap(None);
 
             while !self.is_exit {
                 if event::poll(Duration::from_millis(50)).unwrap_or(false) {
@@ -1009,10 +1054,21 @@ impl App {
 
     pub fn sync(&mut self, repo: &git2::Repository) {
         let mut events = Vec::new();
+        let mut is_disconnected = false;
         if let Some(rx) = &self.graph_rx {
-            while let Ok(event) = rx.try_recv() {
-                events.push(event);
+            loop {
+                match rx.try_recv() {
+                    Ok(event) => events.push(event),
+                    Err(std::sync::mpsc::TryRecvError::Empty) => break,
+                    Err(std::sync::mpsc::TryRecvError::Disconnected) => {
+                        is_disconnected = true;
+                        break;
+                    },
+                }
             }
+        }
+        if is_disconnected {
+            self.graph_rx = None;
         }
 
         for event in events {
@@ -1035,14 +1091,18 @@ impl App {
                         self.viewport = Viewport::Graph;
                     }
 
-                    match get_filenames_diff_at_workdir(repo) {
-                        Ok(uncommitted) => {
-                            self.uncommitted = uncommitted;
-                        },
-                        Err(error) => {
-                            self.uncommitted = UncommittedChanges::default();
-                            self.show_error(errors::with_error(errors::FILE_DIFF(), error));
-                        },
+                    if self.skip_workdir_status {
+                        self.uncommitted = UncommittedChanges::default();
+                    } else {
+                        match get_filenames_diff_at_workdir(repo) {
+                            Ok(uncommitted) => {
+                                self.uncommitted = uncommitted;
+                            },
+                            Err(error) => {
+                                self.uncommitted = UncommittedChanges::default();
+                                self.show_error(errors::with_error(errors::FILE_DIFF(), error));
+                            },
+                        }
                     }
                     self.is_uncommitted_loaded = true;
                 }

--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -1251,7 +1251,7 @@ impl App {
             return None;
         }
 
-        self.oids.get_sorted_aliases().get(index).map(|&alias| GraphIndexIdentity { index, alias, oid: self.oids.get_git2_oid_by_alias(alias) })
+        self.oids.get_sorted_aliases().get(index).map(|&alias| GraphIndexIdentity { index, alias, oid: self.oids.get_oid_by_alias(alias) })
     }
 
     pub(crate) fn graph_alias_at(&self, index: usize) -> Option<u32> {

--- a/src/app/draw/stashes.rs
+++ b/src/app/draw/stashes.rs
@@ -67,8 +67,8 @@ impl App {
             }
         } else if self.graph_tx.is_none() {
             for stash_alias in &self.oids.stashes {
-                let oid = self.oids.get_oid_by_alias(*stash_alias);
-                let commit = repo.find_commit(*oid).unwrap();
+                let oid = self.oids.get_git2_oid_by_alias(*stash_alias);
+                let commit = repo.find_commit(oid).unwrap();
                 let message = commit.summary().unwrap_or(empty::NO_MESSAGE()).to_string();
 
                 let truncated = truncate_with_ellipsis(message.as_str(), max_text_width.saturating_sub(1));

--- a/src/app/draw/stashes.rs
+++ b/src/app/draw/stashes.rs
@@ -67,7 +67,7 @@ impl App {
             }
         } else if self.graph_tx.is_none() {
             for stash_alias in &self.oids.stashes {
-                let oid = self.oids.get_git2_oid_by_alias(*stash_alias);
+                let oid = self.oids.get_oid_by_alias(*stash_alias);
                 let commit = repo.find_commit(oid).unwrap();
                 let message = commit.summary().unwrap_or(empty::NO_MESSAGE()).to_string();
 

--- a/src/app/input/git.rs
+++ b/src/app/input/git.rs
@@ -378,7 +378,7 @@ impl App {
                 let Some(alias) = self.stash_alias_at_pane_selection() else {
                     return;
                 };
-                self.oids.get_git2_oid_by_alias(alias)
+                self.oids.get_oid_by_alias(alias)
             },
             _ => return,
         };
@@ -418,7 +418,7 @@ impl App {
                 let Some(alias) = self.stash_alias_at_pane_selection() else {
                     return;
                 };
-                self.oids.get_git2_oid_by_alias(alias)
+                self.oids.get_oid_by_alias(alias)
             },
             _ => return,
         };

--- a/src/app/input/git.rs
+++ b/src/app/input/git.rs
@@ -378,7 +378,7 @@ impl App {
                 let Some(alias) = self.stash_alias_at_pane_selection() else {
                     return;
                 };
-                *self.oids.get_oid_by_alias(alias)
+                self.oids.get_git2_oid_by_alias(alias)
             },
             _ => return,
         };
@@ -418,7 +418,7 @@ impl App {
                 let Some(alias) = self.stash_alias_at_pane_selection() else {
                     return;
                 };
-                *self.oids.get_oid_by_alias(alias)
+                self.oids.get_git2_oid_by_alias(alias)
             },
             _ => return,
         };

--- a/src/app/input/modals.rs
+++ b/src/app/input/modals.rs
@@ -16,7 +16,6 @@ use crate::{
         localisation::{errors, operations},
     },
 };
-use git2::Oid;
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use std::path::PathBuf;
 
@@ -616,10 +615,7 @@ impl App {
                             return true;
                         }
 
-                        let oid: Option<Oid> = self.oids.oids.iter().find(|oid| oid.to_string().starts_with(sha)).copied();
-
-                        if let Some(oid) = oid {
-                            let oid_alias = self.oids.get_alias_by_oid(oid);
+                        if let Some(oid_alias) = self.oids.get_alias_by_prefix(sha) {
                             let next = self.oids.get_sorted_aliases().iter().position(|&alias| alias == oid_alias).unwrap();
 
                             self.graph_selected = next;

--- a/src/app/input/navigation.rs
+++ b/src/app/input/navigation.rs
@@ -1622,7 +1622,7 @@ impl App {
                     .iter()
                     .enumerate()
                     .filter_map(|(idx, &alias)| {
-                        let child_oid = self.oids.get_git2_oid_by_alias(alias);
+                        let child_oid = self.oids.get_oid_by_alias(alias);
                         let commit = repo.find_commit(child_oid).ok()?;
                         if commit.parent_ids().any(|parent_oid| parent_oid == oid) { Some(idx) } else { None }
                     })

--- a/src/app/input/navigation.rs
+++ b/src/app/input/navigation.rs
@@ -1622,8 +1622,8 @@ impl App {
                     .iter()
                     .enumerate()
                     .filter_map(|(idx, &alias)| {
-                        let child_oid = self.oids.get_oid_by_alias(alias);
-                        let commit = repo.find_commit(*child_oid).ok()?;
+                        let child_oid = self.oids.get_git2_oid_by_alias(alias);
+                        let commit = repo.find_commit(child_oid).ok()?;
                         if commit.parent_ids().any(|parent_oid| parent_oid == oid) { Some(idx) } else { None }
                     })
                     .collect();
@@ -1662,7 +1662,7 @@ impl App {
                     return;
                 };
                 self.graph.graph_window.as_ref().and_then(|window| window.rows.iter().find(|row| row.oid == parent_oid).map(|row| row.index)).or_else(|| {
-                    let parent_alias = self.oids.aliases.get(&parent_oid).copied()?;
+                    let parent_alias = self.oids.get_existing_alias(parent_oid)?;
                     self.oids.get_sorted_aliases().iter().position(|&alias| alias == parent_alias)
                 })
             };

--- a/src/app/input/worktrees.rs
+++ b/src/app/input/worktrees.rs
@@ -32,7 +32,7 @@ impl App {
                 .entries
                 .iter()
                 .enumerate()
-                .filter_map(|(idx, entry)| entry.head.and_then(|oid| self.oids.aliases.get(&oid)).is_some_and(|current| *current == alias).then_some(idx))
+                .filter_map(|(idx, entry)| entry.head.and_then(|oid| self.oids.get_existing_alias(oid)).is_some_and(|current| current == alias).then_some(idx))
                 .collect();
         }
 

--- a/src/app/state/defaults.rs
+++ b/src/app/state/defaults.rs
@@ -239,6 +239,7 @@ impl Default for App {
 
             // Exit
             is_exit: false,
+            skip_workdir_status: false,
         }
     }
 }

--- a/src/app/state/defaults.rs
+++ b/src/app/state/defaults.rs
@@ -239,7 +239,6 @@ impl Default for App {
 
             // Exit
             is_exit: false,
-            skip_workdir_status: false,
         }
     }
 }

--- a/src/core/graph_service.rs
+++ b/src/core/graph_service.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     git::queries::{file_history::changed_file_status_at_commit, helpers::FileStatus, reflogs::HeadReflogEntry},
     helpers::{
-        heatmap::{DAYS, WEEKS, build_heatmap_from_sorted_aliases, empty_heatmap},
+        heatmap::{DAYS, WEEKS, build_heatmap_from_sorted_aliases},
         localisation::{common, empty, errors, status as status_text},
         symbols::SymbolTheme,
         time::timestamp_to_utc_date_time,
@@ -162,7 +162,6 @@ pub fn spawn_graph_service(config: GraphServiceConfig, rx: Receiver<GraphCommand
 
 fn run_graph_service(config: GraphServiceConfig, rx: Receiver<GraphCommand>, tx: Sender<GraphEvent>, cancel: Arc<AtomicBool>) {
     let generation = config.generation;
-    let repo_path = config.path.clone();
     let mut walk_ctx = match Walker::new(config.path, config.amount, config.hidden_branch_names.clone(), config.include_head_reflog_roots, config.graph_lane_limit) {
         Ok(walker) => walker,
         Err(error) => {
@@ -218,7 +217,8 @@ fn run_graph_service(config: GraphServiceConfig, rx: Receiver<GraphCommand>, tx:
         is_first = false;
 
         if is_complete {
-            let heatmap = gix::open(&repo_path).map(|repo| build_heatmap_from_sorted_aliases(&repo, &walk_ctx.oids)).unwrap_or_else(|_| empty_heatmap());
+            let repo = walk_ctx.repo.borrow();
+            let heatmap = build_heatmap_from_sorted_aliases(&repo, &walk_ctx.oids);
             let _ = tx.send(GraphEvent::Heatmap { generation, heatmap });
 
             if let Some((request_id, path)) = pending_file_history.take() {

--- a/src/core/graph_service.rs
+++ b/src/core/graph_service.rs
@@ -315,7 +315,7 @@ fn file_history_rows(walk_ctx: &Walker, path: &str, symbols: &SymbolTheme) -> Re
     let mut rows = Vec::new();
 
     for (graph_index, &alias) in walk_ctx.oids.get_sorted_aliases().iter().enumerate() {
-        let oid = walk_ctx.oids.get_git2_oid_by_alias(alias);
+        let oid = walk_ctx.oids.get_oid_by_alias(alias);
         if oid.is_zero() {
             continue;
         }
@@ -343,7 +343,7 @@ fn graph_rows(walk_ctx: &Walker, worktrees: &Worktrees, hidden_branch_names: &Ha
 
     for index in start..end {
         let alias = walk_ctx.oids.get_sorted_aliases().get(index).copied().unwrap_or(NONE);
-        let oid = walk_ctx.oids.get_git2_oid_by_alias(alias);
+        let oid = walk_ctx.oids.get_oid_by_alias(alias);
         let is_uncommitted = alias == NONE || oid.is_zero();
         let (summary, committer_date, committer_name, is_merge_commit) = if is_uncommitted {
             (String::new(), String::new(), String::new(), false)
@@ -418,7 +418,7 @@ fn pane_rows(pane: GraphPane, walk_ctx: &Walker) -> Vec<GraphPaneRow> {
                 .stashes
                 .iter()
                 .map(|&alias| {
-                    let oid = walk_ctx.oids.get_git2_oid_by_alias(alias);
+                    let oid = walk_ctx.oids.get_oid_by_alias(alias);
                     let summary = repo.find_commit(oid).ok().and_then(|commit| commit.summary().map(str::to_string)).unwrap_or_else(|| status_text::STASH().to_string());
                     GraphPaneRow::Stash { alias, summary, lane: walk_ctx.stashes_lanes.get(&alias).copied(), graph_index: index_map.get(&alias).copied() }
                 })
@@ -477,7 +477,7 @@ fn branch_index(walk_ctx: &Walker, hidden_branch_names: &HashSet<String>, from: 
 }
 
 fn parent_index(walk_ctx: &Walker, index: usize) -> Option<usize> {
-    let oid = walk_ctx.oids.get_sorted_aliases().get(index).map(|&alias| walk_ctx.oids.get_git2_oid_by_alias(alias))?;
+    let oid = walk_ctx.oids.get_sorted_aliases().get(index).map(|&alias| walk_ctx.oids.get_oid_by_alias(alias))?;
     if oid.is_zero() {
         return Some(1).filter(|idx| *idx < walk_ctx.oids.get_commit_count());
     }
@@ -490,14 +490,14 @@ fn parent_index(walk_ctx: &Walker, index: usize) -> Option<usize> {
 }
 
 fn child_index(walk_ctx: &Walker, index: usize) -> Option<usize> {
-    let oid = walk_ctx.oids.get_sorted_aliases().get(index).map(|&alias| walk_ctx.oids.get_git2_oid_by_alias(alias))?;
+    let oid = walk_ctx.oids.get_sorted_aliases().get(index).map(|&alias| walk_ctx.oids.get_oid_by_alias(alias))?;
     if oid.is_zero() {
         return None;
     }
 
     let repo = walk_ctx.repo.borrow();
     walk_ctx.oids.get_sorted_aliases().iter().enumerate().take(index).find_map(|(idx, &alias)| {
-        let child_oid = walk_ctx.oids.get_git2_oid_by_alias(alias);
+        let child_oid = walk_ctx.oids.get_oid_by_alias(alias);
         let child = repo.find_commit(child_oid).ok()?;
         child.parent_ids().any(|parent_oid| parent_oid == oid).then_some(idx)
     })

--- a/src/core/graph_service.rs
+++ b/src/core/graph_service.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     git::queries::{file_history::changed_file_status_at_commit, helpers::FileStatus, reflogs::HeadReflogEntry},
     helpers::{
-        heatmap::{DAYS, WEEKS, build_heatmap},
+        heatmap::{DAYS, WEEKS, build_heatmap_from_sorted_aliases, empty_heatmap},
         localisation::{common, empty, errors, status as status_text},
         symbols::SymbolTheme,
         time::timestamp_to_utc_date_time,
@@ -162,6 +162,7 @@ pub fn spawn_graph_service(config: GraphServiceConfig, rx: Receiver<GraphCommand
 
 fn run_graph_service(config: GraphServiceConfig, rx: Receiver<GraphCommand>, tx: Sender<GraphEvent>, cancel: Arc<AtomicBool>) {
     let generation = config.generation;
+    let repo_path = config.path.clone();
     let mut walk_ctx = match Walker::new(config.path, config.amount, config.hidden_branch_names.clone(), config.include_head_reflog_roots, config.graph_lane_limit) {
         Ok(walker) => walker,
         Err(error) => {
@@ -217,8 +218,7 @@ fn run_graph_service(config: GraphServiceConfig, rx: Receiver<GraphCommand>, tx:
         is_first = false;
 
         if is_complete {
-            let repo = walk_ctx.repo.borrow();
-            let heatmap = build_heatmap(&repo, &walk_ctx.oids.oids);
+            let heatmap = gix::open(&repo_path).map(|repo| build_heatmap_from_sorted_aliases(&repo, &walk_ctx.oids)).unwrap_or_else(|_| empty_heatmap());
             let _ = tx.send(GraphEvent::Heatmap { generation, heatmap });
 
             if let Some((request_id, path)) = pending_file_history.take() {
@@ -315,8 +315,8 @@ fn file_history_rows(walk_ctx: &Walker, path: &str, symbols: &SymbolTheme) -> Re
     let mut rows = Vec::new();
 
     for (graph_index, &alias) in walk_ctx.oids.get_sorted_aliases().iter().enumerate() {
-        let oid = *walk_ctx.oids.get_oid_by_alias(alias);
-        if walk_ctx.oids.is_zero(&oid) {
+        let oid = walk_ctx.oids.get_git2_oid_by_alias(alias);
+        if oid.is_zero() {
             continue;
         }
 
@@ -343,8 +343,8 @@ fn graph_rows(walk_ctx: &Walker, worktrees: &Worktrees, hidden_branch_names: &Ha
 
     for index in start..end {
         let alias = walk_ctx.oids.get_sorted_aliases().get(index).copied().unwrap_or(NONE);
-        let oid = *walk_ctx.oids.get_oid_by_alias(alias);
-        let is_uncommitted = alias == NONE || walk_ctx.oids.is_zero(&oid);
+        let oid = walk_ctx.oids.get_git2_oid_by_alias(alias);
+        let is_uncommitted = alias == NONE || oid.is_zero();
         let (summary, committer_date, committer_name, is_merge_commit) = if is_uncommitted {
             (String::new(), String::new(), String::new(), false)
         } else if let Ok(commit) = repo.find_commit(oid) {
@@ -418,7 +418,7 @@ fn pane_rows(pane: GraphPane, walk_ctx: &Walker) -> Vec<GraphPaneRow> {
                 .stashes
                 .iter()
                 .map(|&alias| {
-                    let oid = *walk_ctx.oids.get_oid_by_alias(alias);
+                    let oid = walk_ctx.oids.get_git2_oid_by_alias(alias);
                     let summary = repo.find_commit(oid).ok().and_then(|commit| commit.summary().map(str::to_string)).unwrap_or_else(|| status_text::STASH().to_string());
                     GraphPaneRow::Stash { alias, summary, lane: walk_ctx.stashes_lanes.get(&alias).copied(), graph_index: index_map.get(&alias).copied() }
                 })
@@ -428,7 +428,7 @@ fn pane_rows(pane: GraphPane, walk_ctx: &Walker) -> Vec<GraphPaneRow> {
             .head_reflog_entries
             .iter()
             .filter_map(|entry| {
-                let alias = walk_ctx.oids.aliases.get(&entry.new_oid).copied()?;
+                let alias = walk_ctx.oids.get_existing_alias(entry.new_oid)?;
                 Some(GraphPaneRow::Reflog {
                     alias,
                     selector: entry.selector.clone(),
@@ -447,12 +447,11 @@ fn lookup(kind: GraphLookupKind, walk_ctx: &Walker, worktrees: &Worktrees, hidde
         GraphLookupKind::PaneRowAt { pane, index } => GraphLookupResult::PaneRow(pane_rows(pane, walk_ctx).get(index).cloned()),
         GraphLookupKind::BranchIndex { from, direction } => GraphLookupResult::Index(branch_index(walk_ctx, hidden_branch_names, from, direction)),
         GraphLookupKind::ShaPrefix { prefix } => {
-            let oid = walk_ctx.oids.oids.iter().find(|oid| oid.to_string().starts_with(&prefix)).copied();
-            let index = oid.and_then(|oid| walk_ctx.oids.aliases.get(&oid).copied()).and_then(|alias| walk_ctx.oids.get_sorted_aliases().iter().position(|&current| current == alias));
+            let index = walk_ctx.oids.get_alias_by_prefix(&prefix).and_then(|alias| walk_ctx.oids.get_sorted_aliases().iter().position(|&current| current == alias));
             GraphLookupResult::Index(index)
         },
         GraphLookupKind::Oid { oid } => {
-            let index = walk_ctx.oids.aliases.get(&oid).copied().and_then(|alias| walk_ctx.oids.get_sorted_aliases().iter().position(|&current| current == alias));
+            let index = walk_ctx.oids.get_existing_alias(oid).and_then(|alias| walk_ctx.oids.get_sorted_aliases().iter().position(|&current| current == alias));
             GraphLookupResult::Index(index)
         },
         GraphLookupKind::ParentIndex { index } => GraphLookupResult::Index(parent_index(walk_ctx, index)),
@@ -478,27 +477,27 @@ fn branch_index(walk_ctx: &Walker, hidden_branch_names: &HashSet<String>, from: 
 }
 
 fn parent_index(walk_ctx: &Walker, index: usize) -> Option<usize> {
-    let oid = walk_ctx.oids.get_sorted_aliases().get(index).map(|&alias| *walk_ctx.oids.get_oid_by_alias(alias))?;
-    if walk_ctx.oids.is_zero(&oid) {
+    let oid = walk_ctx.oids.get_sorted_aliases().get(index).map(|&alias| walk_ctx.oids.get_git2_oid_by_alias(alias))?;
+    if oid.is_zero() {
         return Some(1).filter(|idx| *idx < walk_ctx.oids.get_commit_count());
     }
 
     let repo = walk_ctx.repo.borrow();
     let commit = repo.find_commit(oid).ok()?;
     let parent_oid = commit.parent_ids().next()?;
-    let parent_alias = walk_ctx.oids.aliases.get(&parent_oid).copied()?;
+    let parent_alias = walk_ctx.oids.get_existing_alias(parent_oid)?;
     walk_ctx.oids.get_sorted_aliases().iter().position(|&alias| alias == parent_alias)
 }
 
 fn child_index(walk_ctx: &Walker, index: usize) -> Option<usize> {
-    let oid = walk_ctx.oids.get_sorted_aliases().get(index).map(|&alias| *walk_ctx.oids.get_oid_by_alias(alias))?;
-    if walk_ctx.oids.is_zero(&oid) {
+    let oid = walk_ctx.oids.get_sorted_aliases().get(index).map(|&alias| walk_ctx.oids.get_git2_oid_by_alias(alias))?;
+    if oid.is_zero() {
         return None;
     }
 
     let repo = walk_ctx.repo.borrow();
     walk_ctx.oids.get_sorted_aliases().iter().enumerate().take(index).find_map(|(idx, &alias)| {
-        let child_oid = *walk_ctx.oids.get_oid_by_alias(alias);
+        let child_oid = walk_ctx.oids.get_git2_oid_by_alias(alias);
         let child = repo.find_commit(child_oid).ok()?;
         child.parent_ids().any(|parent_oid| parent_oid == oid).then_some(idx)
     })
@@ -506,7 +505,7 @@ fn child_index(walk_ctx: &Walker, index: usize) -> Option<usize> {
 
 fn head_alias(walk_ctx: &Walker) -> u32 {
     let repo = walk_ctx.repo.borrow();
-    repo.head().ok().and_then(|head| head.target()).and_then(|oid| walk_ctx.oids.aliases.get(&oid).copied()).unwrap_or(NONE)
+    repo.head().ok().and_then(|head| head.target()).and_then(|oid| walk_ctx.oids.get_existing_alias(oid)).unwrap_or(NONE)
 }
 
 fn alias_index_map(walk_ctx: &Walker) -> HashMap<u32, usize> {
@@ -516,7 +515,7 @@ fn alias_index_map(walk_ctx: &Walker) -> HashMap<u32, usize> {
 fn latest_reflogs_by_alias(walk_ctx: &Walker) -> HashMap<u32, HeadReflogAliasEntry> {
     let mut latest = HashMap::new();
     for entry in &walk_ctx.head_reflog_entries {
-        let Some(&new_alias) = walk_ctx.oids.aliases.get(&entry.new_oid) else {
+        let Some(new_alias) = walk_ctx.oids.get_existing_alias(entry.new_oid) else {
             continue;
         };
         let alias_entry = alias_reflog_entry(entry, new_alias);
@@ -534,7 +533,7 @@ fn worktrees_for_alias(worktrees: &Worktrees, walk_ctx: &Walker, alias: u32) -> 
         .entries
         .iter()
         .filter_map(|entry| {
-            let entry_alias = entry.head.and_then(|oid| walk_ctx.oids.aliases.get(&oid).copied());
+            let entry_alias = entry.head.and_then(|oid| walk_ctx.oids.get_existing_alias(oid));
             (entry_alias == Some(alias)).then(|| {
                 let mut entry = entry.clone();
                 entry.alias = Some(alias);

--- a/src/core/oids.rs
+++ b/src/core/oids.rs
@@ -1,43 +1,128 @@
 use crate::core::chunk::NONE;
 use git2::Oid;
-use std::collections::HashMap;
+use gix::ObjectId;
+use iddqd::{IdHashItem, IdHashMap, id_upcast};
+
+pub trait IntoGixOid {
+    fn into_gix_oid(self) -> ObjectId;
+}
+
+impl IntoGixOid for ObjectId {
+    fn into_gix_oid(self) -> ObjectId {
+        self
+    }
+}
+
+impl IntoGixOid for Oid {
+    fn into_gix_oid(self) -> ObjectId {
+        git2_to_gix_oid(self)
+    }
+}
+
+pub fn git2_to_gix_oid(oid: Oid) -> gix::ObjectId {
+    gix::ObjectId::from_bytes_or_panic(oid.as_bytes())
+}
+
+#[cfg(test)]
+#[path = "../tests/core/oids.rs"]
+mod tests;
+
+pub fn gix_to_git2_oid(oid: gix::ObjectId) -> Oid {
+    Oid::from_bytes(oid.as_bytes()).unwrap()
+}
 
 // Stores full OIDs once and passes small numeric aliases through UI data structures.
 #[derive(Clone)]
 pub struct Oids {
-    pub zero: Oid,
-    pub oids: Vec<Oid>,
-    pub aliases: HashMap<Oid, u32>,
+    pub zero: ObjectId,
+    records: IdHashMap<OidRecord>,
+    alias_oids: Vec<ObjectId>,
     pub sorted_aliases: Vec<u32>,
     pub stashes: Vec<u32>,
 }
 
+#[derive(Clone, Debug)]
+struct OidRecord {
+    oid: ObjectId,
+    alias: u32,
+}
+
+impl IdHashItem for OidRecord {
+    type Key<'a> = &'a ObjectId;
+
+    fn key(&self) -> Self::Key<'_> {
+        &self.oid
+    }
+
+    id_upcast!();
+}
+
 impl Default for Oids {
     fn default() -> Self {
-        Oids { zero: Oid::zero(), oids: Vec::new(), aliases: HashMap::new(), sorted_aliases: vec![NONE], stashes: vec![] }
+        Oids { zero: ObjectId::null(gix::hash::Kind::Sha1), records: IdHashMap::default(), alias_oids: Vec::new(), sorted_aliases: vec![NONE], stashes: vec![] }
     }
 }
 
 impl Oids {
-    pub fn get_alias_by_oid(&mut self, oid: Oid) -> u32 {
-        // Assign aliases lazily so refs, commits, tags, and stashes share one namespace.
-        *self.aliases.entry(oid).or_insert_with(|| {
-            self.oids.push(oid);
-            self.oids.len() as u32 - 1
-        })
+    pub fn reserve_total_aliases(&mut self, total: usize) {
+        let sorted_target = total.saturating_add(1);
+        let sorted_spare = self.sorted_aliases.capacity().saturating_sub(self.sorted_aliases.len());
+        if sorted_target > self.sorted_aliases.len() + sorted_spare {
+            self.sorted_aliases.reserve(sorted_target - self.sorted_aliases.len() - sorted_spare);
+        }
+
+        let alias_spare = self.alias_oids.capacity().saturating_sub(self.alias_oids.len());
+        if total > self.alias_oids.len() + alias_spare {
+            self.alias_oids.reserve(total - self.alias_oids.len() - alias_spare);
+        }
+    }
+
+    pub fn reserve_aliases(&mut self, additional: usize) {
+        let sorted_spare = self.sorted_aliases.capacity().saturating_sub(self.sorted_aliases.len());
+        if additional > sorted_spare {
+            self.sorted_aliases.reserve(additional - sorted_spare);
+        }
+
+        let alias_spare = self.alias_oids.capacity().saturating_sub(self.alias_oids.len());
+        if additional > alias_spare {
+            self.alias_oids.reserve(additional - alias_spare);
+        }
+    }
+
+    pub fn shrink_to_fit(&mut self) {
+        self.alias_oids.shrink_to_fit();
+        self.sorted_aliases.shrink_to_fit();
+        self.stashes.shrink_to_fit();
+    }
+
+    pub fn get_alias_by_oid(&mut self, oid: impl IntoGixOid) -> u32 {
+        let oid = oid.into_gix_oid();
+        if let Some(record) = self.records.get(&oid) {
+            return record.alias;
+        }
+
+        let alias = u32::try_from(self.alias_oids.len()).expect("OID alias space exhausted");
+        self.alias_oids.push(oid);
+        self.records.insert_unique(OidRecord { oid, alias }).expect("new OID record has unique OID");
+
+        alias
+    }
+
+    pub fn get_existing_alias(&self, oid: impl IntoGixOid) -> Option<u32> {
+        let oid = oid.into_gix_oid();
+        self.records.get(&oid).map(|record| record.alias)
     }
 
     pub fn get_alias_by_idx(&self, idx: usize) -> u32 {
         *self.sorted_aliases.get(idx).unwrap()
     }
 
-    pub fn get_oid_by_alias(&self, alias: u32) -> &Oid {
-        self.oids.get(alias as usize).unwrap_or(&self.zero)
+    pub fn get_oid_by_alias(&self, alias: u32) -> &ObjectId {
+        self.alias_oids.get(alias as usize).unwrap_or(&self.zero)
     }
 
-    pub fn get_oid_by_idx(&self, idx: usize) -> &Oid {
-        let alias = *self.sorted_aliases.get(idx).unwrap_or(&NONE);
-        self.oids.get(alias as usize).unwrap_or(&self.zero)
+    pub fn get_git2_oid_by_alias(&self, alias: u32) -> Oid {
+        gix_to_git2_oid(*self.get_oid_by_alias(alias))
     }
 
     pub fn get_sorted_aliases(&self) -> &Vec<u32> {
@@ -52,7 +137,39 @@ impl Oids {
         self.sorted_aliases.len()
     }
 
-    pub fn is_zero(&self, oid: &Oid) -> bool {
+    pub fn len(&self) -> usize {
+        self.alias_oids.len()
+    }
+
+    pub fn iter_oids(&self) -> impl Iterator<Item = &ObjectId> {
+        self.alias_oids.iter()
+    }
+
+    pub fn get_alias_by_prefix(&self, prefix: &str) -> Option<u32> {
+        self.alias_oids.iter().position(|oid| oid_starts_with_hex_prefix(oid, prefix)).and_then(|alias| u32::try_from(alias).ok())
+    }
+
+    pub fn is_zero(&self, oid: &ObjectId) -> bool {
         self.zero == *oid
+    }
+}
+
+fn oid_starts_with_hex_prefix(oid: &ObjectId, prefix: &str) -> bool {
+    prefix.bytes().enumerate().all(|(idx, byte)| {
+        let Some(nibble) = hex_nibble(byte) else {
+            return false;
+        };
+        let oid_byte = oid.as_bytes()[idx / 2];
+        let oid_nibble = if idx % 2 == 0 { oid_byte >> 4 } else { oid_byte & 0x0f };
+        nibble == oid_nibble
+    })
+}
+
+fn hex_nibble(byte: u8) -> Option<u8> {
+    match byte {
+        b'0'..=b'9' => Some(byte - b'0'),
+        b'a'..=b'f' => Some(byte - b'a' + 10),
+        b'A'..=b'F' => Some(byte - b'A' + 10),
+        _ => None,
     }
 }

--- a/src/core/oids.rs
+++ b/src/core/oids.rs
@@ -65,28 +65,13 @@ impl Default for Oids {
 
 impl Oids {
     pub fn reserve_total_aliases(&mut self, total: usize) {
-        let sorted_target = total.saturating_add(1);
-        let sorted_spare = self.sorted_aliases.capacity().saturating_sub(self.sorted_aliases.len());
-        if sorted_target > self.sorted_aliases.len() + sorted_spare {
-            self.sorted_aliases.reserve(sorted_target - self.sorted_aliases.len() - sorted_spare);
-        }
-
-        let alias_spare = self.alias_oids.capacity().saturating_sub(self.alias_oids.len());
-        if total > self.alias_oids.len() + alias_spare {
-            self.alias_oids.reserve(total - self.alias_oids.len() - alias_spare);
-        }
+        reserve_vec(&mut self.sorted_aliases, total.saturating_add(1));
+        reserve_vec(&mut self.alias_oids, total);
     }
 
     pub fn reserve_aliases(&mut self, additional: usize) {
-        let sorted_spare = self.sorted_aliases.capacity().saturating_sub(self.sorted_aliases.len());
-        if additional > sorted_spare {
-            self.sorted_aliases.reserve(additional - sorted_spare);
-        }
-
-        let alias_spare = self.alias_oids.capacity().saturating_sub(self.alias_oids.len());
-        if additional > alias_spare {
-            self.alias_oids.reserve(additional - alias_spare);
-        }
+        self.sorted_aliases.reserve(additional);
+        self.alias_oids.reserve(additional);
     }
 
     pub fn shrink_to_fit(&mut self) {
@@ -125,7 +110,7 @@ impl Oids {
         gix_to_git2_oid(*self.get_oid_by_alias(alias))
     }
 
-    pub fn get_sorted_aliases(&self) -> &Vec<u32> {
+    pub fn get_sorted_aliases(&self) -> &[u32] {
         &self.sorted_aliases
     }
 
@@ -146,7 +131,7 @@ impl Oids {
     }
 
     pub fn get_alias_by_prefix(&self, prefix: &str) -> Option<u32> {
-        self.alias_oids.iter().position(|oid| oid_starts_with_hex_prefix(oid, prefix)).and_then(|alias| u32::try_from(alias).ok())
+        (!prefix.is_empty()).then(|| self.alias_oids.iter().position(|oid| matches_ascii_hex_prefix(oid, prefix))).flatten().and_then(|alias| u32::try_from(alias).ok())
     }
 
     pub fn is_zero(&self, oid: &ObjectId) -> bool {
@@ -154,9 +139,13 @@ impl Oids {
     }
 }
 
-fn oid_starts_with_hex_prefix(oid: &ObjectId, prefix: &str) -> bool {
+fn reserve_vec<T>(vec: &mut Vec<T>, target_len: usize) {
+    vec.reserve(target_len.saturating_sub(vec.len()));
+}
+
+fn matches_ascii_hex_prefix(oid: &ObjectId, prefix: &str) -> bool {
     prefix.bytes().enumerate().all(|(idx, byte)| {
-        let Some(nibble) = hex_nibble(byte) else {
+        let Some(nibble) = ascii_hex_nibble(byte) else {
             return false;
         };
         let oid_byte = oid.as_bytes()[idx / 2];
@@ -165,7 +154,7 @@ fn oid_starts_with_hex_prefix(oid: &ObjectId, prefix: &str) -> bool {
     })
 }
 
-fn hex_nibble(byte: u8) -> Option<u8> {
+fn ascii_hex_nibble(byte: u8) -> Option<u8> {
     match byte {
         b'0'..=b'9' => Some(byte - b'0'),
         b'a'..=b'f' => Some(byte - b'a' + 10),

--- a/src/core/oids.rs
+++ b/src/core/oids.rs
@@ -102,12 +102,12 @@ impl Oids {
         *self.sorted_aliases.get(idx).unwrap()
     }
 
-    pub fn get_oid_by_alias(&self, alias: u32) -> &ObjectId {
+    pub fn get_gix_oid_by_alias(&self, alias: u32) -> &ObjectId {
         self.alias_oids.get(alias as usize).unwrap_or(&self.zero)
     }
 
-    pub fn get_git2_oid_by_alias(&self, alias: u32) -> Oid {
-        gix_to_git2_oid(*self.get_oid_by_alias(alias))
+    pub fn get_oid_by_alias(&self, alias: u32) -> Oid {
+        gix_to_git2_oid(*self.get_gix_oid_by_alias(alias))
     }
 
     pub fn get_sorted_aliases(&self) -> &[u32] {

--- a/src/core/oids.rs
+++ b/src/core/oids.rs
@@ -131,7 +131,11 @@ impl Oids {
     }
 
     pub fn get_alias_by_prefix(&self, prefix: &str) -> Option<u32> {
-        (!prefix.is_empty()).then(|| self.alias_oids.iter().position(|oid| matches_ascii_hex_prefix(oid, prefix))).flatten().and_then(|alias| u32::try_from(alias).ok())
+        if !is_git_hex_prefix(prefix) {
+            return None;
+        }
+
+        self.alias_oids.iter().position(|oid| matches_ascii_hex_prefix(oid, prefix)).and_then(|alias| u32::try_from(alias).ok())
     }
 
     pub fn is_zero(&self, oid: &ObjectId) -> bool {
@@ -144,14 +148,11 @@ fn reserve_vec<T>(vec: &mut Vec<T>, target_len: usize) {
 }
 
 fn matches_ascii_hex_prefix(oid: &ObjectId, prefix: &str) -> bool {
-    prefix.bytes().enumerate().all(|(idx, byte)| {
-        let Some(nibble) = ascii_hex_nibble(byte) else {
-            return false;
-        };
-        let oid_byte = oid.as_bytes()[idx / 2];
-        let oid_nibble = if idx % 2 == 0 { oid_byte >> 4 } else { oid_byte & 0x0f };
-        nibble == oid_nibble
-    })
+    prefix.bytes().enumerate().all(|(idx, byte)| ascii_hex_nibble(byte).zip(oid_hex_nibble(oid, idx)).is_some_and(|(prefix, oid)| prefix == oid))
+}
+
+fn oid_hex_nibble(oid: &ObjectId, idx: usize) -> Option<u8> {
+    oid.as_bytes().get(idx / 2).map(|byte| if idx % 2 == 0 { byte >> 4 } else { byte & 0x0f })
 }
 
 fn ascii_hex_nibble(byte: u8) -> Option<u8> {

--- a/src/core/oids.rs
+++ b/src/core/oids.rs
@@ -151,6 +151,10 @@ fn matches_ascii_hex_prefix(oid: &ObjectId, prefix: &str) -> bool {
     prefix.bytes().enumerate().all(|(idx, byte)| ascii_hex_nibble(byte).zip(oid_hex_nibble(oid, idx)).is_some_and(|(prefix, oid)| prefix == oid))
 }
 
+fn is_git_hex_prefix(prefix: &str) -> bool {
+    !prefix.is_empty() && prefix.as_bytes().iter().all(u8::is_ascii_hexdigit)
+}
+
 fn oid_hex_nibble(oid: &ObjectId, idx: usize) -> Option<u8> {
     oid.as_bytes().get(idx / 2).map(|byte| if idx % 2 == 0 { byte >> 4 } else { byte & 0x0f })
 }

--- a/src/core/walker.rs
+++ b/src/core/walker.rs
@@ -77,7 +77,7 @@ impl Walker {
         let stash_aliases: StdHashSet<u32> = oids.stashes.iter().copied().collect();
         let mut stash_parent_aliases = Vec::with_capacity(oids.stashes.len());
         for stash_alias in oids.stashes.clone() {
-            let parent_oid = repo.borrow().find_commit(oids.get_git2_oid_by_alias(stash_alias)).ok().and_then(|commit| commit.parent_ids().next());
+            let parent_oid = repo.borrow().find_commit(oids.get_oid_by_alias(stash_alias)).ok().and_then(|commit| commit.parent_ids().next());
             if let Some(parent_oid) = parent_oid {
                 let parent_alias = oids.get_alias_by_oid(parent_oid);
                 stash_parent_aliases.push((stash_alias, parent_alias));
@@ -152,7 +152,7 @@ impl Walker {
         for &alias in sorted_batch.iter() {
             let mut merger_alias: u32 = NONE;
             let mut transient_lane: Option<usize> = None;
-            let oid = self.oids.get_git2_oid_by_alias(alias);
+            let oid = self.oids.get_oid_by_alias(alias);
             let commit = repo.find_commit(oid).unwrap();
 
             // Only two parents are modeled because the renderer draws one merge edge.

--- a/src/core/walker.rs
+++ b/src/core/walker.rs
@@ -77,7 +77,7 @@ impl Walker {
         let stash_aliases: StdHashSet<u32> = oids.stashes.iter().copied().collect();
         let mut stash_parent_aliases = Vec::with_capacity(oids.stashes.len());
         for stash_alias in oids.stashes.clone() {
-            let parent_oid = repo.borrow().find_commit(*oids.get_oid_by_alias(stash_alias)).ok().and_then(|commit| commit.parent_ids().next());
+            let parent_oid = repo.borrow().find_commit(oids.get_git2_oid_by_alias(stash_alias)).ok().and_then(|commit| commit.parent_ids().next());
             if let Some(parent_oid) = parent_oid {
                 let parent_alias = oids.get_alias_by_oid(parent_oid);
                 stash_parent_aliases.push((stash_alias, parent_alias));
@@ -152,8 +152,8 @@ impl Walker {
         for &alias in sorted_batch.iter() {
             let mut merger_alias: u32 = NONE;
             let mut transient_lane: Option<usize> = None;
-            let oid = self.oids.get_oid_by_alias(alias);
-            let commit = repo.find_commit(*oid).unwrap();
+            let oid = self.oids.get_git2_oid_by_alias(alias);
+            let commit = repo.find_commit(oid).unwrap();
 
             // Only two parents are modeled because the renderer draws one merge edge.
             let mut parents_iter = commit.parent_ids();

--- a/src/git/gix.rs
+++ b/src/git/gix.rs
@@ -1,0 +1,36 @@
+use crate::helpers::branch_visibility::branch_name_from_ref;
+
+pub const HISTORY_OBJECT_CACHE_BYTES: usize = 64 * 1024 * 1024;
+
+pub fn enable_history_object_cache(repo: &mut gix::Repository) {
+    repo.object_cache_size_if_unset(HISTORY_OBJECT_CACHE_BYTES);
+}
+
+pub fn commit_graph_if_available(repo: &gix::Repository) -> Option<gix::commitgraph::Graph> {
+    repo.commit_graph_if_enabled().ok().flatten()
+}
+
+pub fn history_commit_count_hint(repo: &gix::Repository) -> Option<usize> {
+    commit_graph_if_available(repo).map(|graph| graph.num_commits() as usize)
+}
+
+pub fn for_each_branch_tip(repo: &gix::Repository, mut visit: impl FnMut(bool, &str, gix::ObjectId)) -> Result<(), git2::Error> {
+    let references = repo.references().map_err(gix_error)?;
+    for (is_local, references) in [(true, references.local_branches()), (false, references.remote_branches())] {
+        for reference in references.map_err(gix_error)? {
+            let reference = reference.map_err(gix_error)?;
+            let Some(name) = branch_name_from_ref(reference.name().as_bstr()) else {
+                continue;
+            };
+            let Some(oid) = reference.try_id().map(|id| id.detach()) else {
+                continue;
+            };
+            visit(is_local, name, oid);
+        }
+    }
+    Ok(())
+}
+
+pub(crate) fn gix_error(error: impl std::fmt::Display) -> git2::Error {
+    git2::Error::from_str(&error.to_string())
+}

--- a/src/git/test_support.rs
+++ b/src/git/test_support.rs
@@ -1,0 +1,252 @@
+use crate::git::actions::worktrees::create_worktree;
+use git2::{Oid, Repository, Signature, Time, build::CheckoutBuilder};
+use std::{
+    fs,
+    ops::Deref,
+    path::{Path, PathBuf},
+};
+
+pub struct TestDir {
+    dir: tempfile::TempDir,
+}
+
+pub struct LinkedWorktreeFixture {
+    pub repo_path: PathBuf,
+    pub repo: Repository,
+    pub linked_path: PathBuf,
+    pub linked_repo: Repository,
+    pub base: Oid,
+}
+
+impl TestDir {
+    pub fn new(name: &str) -> Self {
+        let dir = tempfile::Builder::new().prefix(&format!("guitar-test-support-{name}-")).tempdir().unwrap();
+        Self { dir }
+    }
+
+    pub fn path(&self) -> &Path {
+        self.dir.path()
+    }
+
+    pub fn join(&self, path: impl AsRef<Path>) -> PathBuf {
+        self.path().join(path)
+    }
+}
+
+impl Deref for TestDir {
+    type Target = Path;
+
+    fn deref(&self) -> &Self::Target {
+        self.path()
+    }
+}
+
+impl AsRef<Path> for TestDir {
+    fn as_ref(&self) -> &Path {
+        self.path()
+    }
+}
+
+pub fn temp_path(prefix: &str, name: &str) -> PathBuf {
+    tempfile::Builder::new().prefix(&format!("{prefix}-{name}-")).tempfile().unwrap().into_temp_path().keep().unwrap()
+}
+
+pub fn temp_json_path(prefix: &str, name: &str) -> PathBuf {
+    tempfile::Builder::new().prefix(&format!("{prefix}-{name}-")).suffix(".json").tempfile().unwrap().into_temp_path().keep().unwrap()
+}
+
+pub fn temp_named_dir(prefix: &str, name: &str) -> PathBuf {
+    tempfile::Builder::new().prefix(&format!("{prefix}-{name}-")).tempdir().unwrap().keep()
+}
+
+pub fn read_to_string(path: &PathBuf) -> String {
+    fs::read_to_string(path).unwrap()
+}
+
+fn configure_user(repo: &Repository) {
+    let mut config = repo.config().unwrap();
+    config.set_str("user.name", "Test User").unwrap();
+    config.set_str("user.email", "test@example.com").unwrap();
+}
+
+pub fn init_repo_at(path: &Path) -> Repository {
+    fs::create_dir_all(path).unwrap();
+    let repo = Repository::init(path).unwrap();
+    configure_user(&repo);
+    repo
+}
+
+pub fn temp_repo(name: &str) -> (TestDir, Repository) {
+    let dir = TestDir::new(name);
+    let repo = init_repo_at(&dir.join("repo"));
+    (dir, repo)
+}
+
+pub fn temp_repo_with_commit(name: &str) -> (TestDir, Repository, Oid) {
+    let (dir, repo) = temp_repo(name);
+    let oid = commit_file(&repo, "file.txt", "content\n", "commit");
+    (dir, repo, oid)
+}
+
+pub fn init_bare_repo_at(path: &Path) -> Repository {
+    fs::create_dir_all(path).unwrap();
+    Repository::init_bare(path).unwrap()
+}
+
+pub fn write_workdir_file(repo: &Repository, relative: &str, contents: &str) {
+    write_path_file(repo.workdir().unwrap(), relative, contents);
+}
+
+pub fn write_path_file(root: &Path, relative: &str, contents: &str) {
+    let full_path = root.join(relative);
+    if let Some(parent) = full_path.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(full_path, contents).unwrap();
+}
+
+pub fn assert_workdir_file(repo: &Repository, relative: &str, expected: &str) {
+    assert_eq!(fs::read_to_string(repo.workdir().unwrap().join(relative)).unwrap(), expected);
+}
+
+pub fn checkout_new_branch(repo: &Repository, name: &str) {
+    let head = repo.head().unwrap().peel_to_commit().unwrap();
+    repo.branch(name, &head, false).unwrap();
+    checkout_branch(repo, name);
+}
+
+pub fn checkout_branch(repo: &Repository, name: &str) {
+    repo.set_head(&format!("refs/heads/{name}")).unwrap();
+    repo.checkout_head(Some(CheckoutBuilder::default().force())).unwrap();
+}
+
+pub fn diverge_file(repo: &Repository, relative: &str) -> (Oid, Oid) {
+    let (_, feature, main) = diverge_files(repo, relative, relative, relative);
+    (feature, main)
+}
+
+pub fn diverge_files(repo: &Repository, base_file: &str, feature_file: &str, main_file: &str) -> (Oid, Oid, Oid) {
+    let base = commit_file(repo, base_file, "base\n", "base");
+    let base_branch = repo.head().unwrap().shorthand().unwrap().to_string();
+    checkout_new_branch(repo, "feature");
+    let feature = commit_file(repo, feature_file, "feature\n", "feature");
+    checkout_branch(repo, &base_branch);
+    let main = commit_file(repo, main_file, "main\n", "main");
+    (base, feature, main)
+}
+
+pub fn stage_path(repo: &Repository, relative: &str) {
+    let mut index = repo.index().unwrap();
+    index.add_path(Path::new(relative)).unwrap();
+    index.write().unwrap();
+}
+
+pub fn commit_index(repo: &Repository, message: &str) -> Oid {
+    let mut index = repo.index().unwrap();
+    index.read(true).unwrap();
+    let tree_id = index.write_tree().unwrap();
+    let tree = repo.find_tree(tree_id).unwrap();
+    let signature = repo.signature().unwrap();
+    let parent = repo.head().ok().and_then(|head| head.peel_to_commit().ok());
+    let parents: Vec<&git2::Commit<'_>> = parent.iter().collect();
+    repo.commit(Some("HEAD"), &signature, &signature, message, &tree, &parents).unwrap()
+}
+
+pub fn commit_file(repo: &Repository, relative: &str, contents: &str, message: &str) -> Oid {
+    write_workdir_file(repo, relative, contents);
+    stage_path(repo, relative);
+    commit_index(repo, message)
+}
+
+pub fn commit_named_file(repo: &Repository, relative: &str, message: &str) -> Oid {
+    commit_file(repo, relative, &format!("{message}\n"), message)
+}
+
+pub fn commit_staged_file(repo: &Repository, relative: &str, message: &str) -> Oid {
+    stage_path(repo, relative);
+    commit_index(repo, message)
+}
+
+pub fn commit_named_files(repo: &Repository, files: &[&str], message: &str) -> Oid {
+    for file in files {
+        write_workdir_file(repo, file, "content\n");
+        stage_path(repo, file);
+    }
+    commit_index(repo, message)
+}
+
+pub fn commit_file_with_parents(repo: &Repository, relative: &str, contents: &str, message: &str, parents: &[Oid], time: Option<i64>) -> Oid {
+    write_workdir_file(repo, relative, contents);
+    stage_path(repo, relative);
+
+    let mut index = repo.index().unwrap();
+    let tree_id = index.write_tree().unwrap();
+    let tree = repo.find_tree(tree_id).unwrap();
+    let signature = time.map_or_else(|| Signature::now("Test User", "test@example.com").unwrap(), |time| Signature::new("Test User", "test@example.com", &Time::new(time, 0)).unwrap());
+    let parent_commits: Vec<_> = parents.iter().map(|oid| repo.find_commit(*oid).unwrap()).collect();
+    let parent_refs: Vec<&git2::Commit<'_>> = parent_commits.iter().collect();
+    let head = repo.head().ok().and_then(|head| head.target());
+    let update_ref = match (head, parents.first()) {
+        (None, None) => Some("HEAD"),
+        (Some(head), Some(parent)) if head == *parent => Some("HEAD"),
+        _ => None,
+    };
+
+    repo.commit(update_ref, &signature, &signature, message, &tree, &parent_refs).unwrap()
+}
+
+pub fn stash_tracked_change(repo: &mut Repository, relative: &str, contents: &str, message: &str) -> Oid {
+    write_workdir_file(repo, relative, contents);
+    let sig = repo.signature().unwrap();
+    repo.stash_save(&sig, message, None).unwrap()
+}
+
+pub fn create_branch(repo: &Repository, name: &str, target: Oid) {
+    let commit = repo.find_commit(target).unwrap();
+    repo.branch(name, &commit, false).unwrap();
+}
+
+pub fn add_remote_path(repo: &Repository, name: &str, remote_path: &Path) {
+    repo.remote(name, remote_path.to_str().unwrap()).unwrap();
+}
+
+pub fn seed_remote(repo: &Repository, remote_name: &str, refspecs: &[&str]) {
+    let mut remote = repo.find_remote(remote_name).unwrap();
+    remote.push(refspecs, None).unwrap();
+}
+
+pub fn source_with_origin(dir: &TestDir) -> (Repository, PathBuf) {
+    let source = init_repo_at(&dir.join("source"));
+    let remote_path = dir.join("remote.git");
+    init_bare_repo_at(&remote_path);
+    add_remote_path(&source, "origin", &remote_path);
+    (source, remote_path)
+}
+
+pub fn linked_worktree_fixture(dir: &TestDir, name: &str) -> LinkedWorktreeFixture {
+    let repo_path = dir.join("repo");
+    let repo = init_repo_at(&repo_path);
+    let base = commit_file(&repo, "file.txt", "base\n", "base");
+    let linked_path = dir.join(name);
+    create_worktree(&repo, name, &linked_path, base).unwrap();
+    let linked_repo = Repository::open(&linked_path).unwrap();
+    LinkedWorktreeFixture { repo_path, repo, linked_path, linked_repo, base }
+}
+
+pub fn parent_with_submodule(dir: &TestDir) -> (Repository, PathBuf) {
+    let child_path = dir.join("child");
+    let parent_path = dir.join("parent");
+    let child = init_repo_at(&child_path);
+    commit_file(&child, "file.txt", "hello from child\n", "child");
+    drop(child);
+
+    let parent = init_repo_at(&parent_path);
+    commit_file(&parent, "file.txt", "hello from parent\n", "parent");
+    let mut submodule = parent.submodule(child_path.to_str().unwrap(), Path::new("deps/child"), true).unwrap();
+    submodule.clone(None).unwrap();
+    submodule.add_finalize().unwrap();
+    commit_index(&parent, "add submodule");
+    drop(submodule);
+
+    (parent, child_path)
+}

--- a/src/git/test_support.rs
+++ b/src/git/test_support.rs
@@ -1,9 +1,11 @@
 use crate::git::actions::worktrees::create_worktree;
-use git2::{Oid, Repository, Signature, Time, build::CheckoutBuilder};
+use crate::helpers::localisation::{Language, set_active_language};
+use git2::{Oid, Repository, RepositoryInitOptions, Signature, Time, build::CheckoutBuilder};
 use std::{
     fs,
     ops::Deref,
     path::{Path, PathBuf},
+    sync::{Mutex, MutexGuard, OnceLock},
 };
 
 pub struct TestDir {
@@ -16,6 +18,21 @@ pub struct LinkedWorktreeFixture {
     pub linked_path: PathBuf,
     pub linked_repo: Repository,
     pub base: Oid,
+}
+
+pub struct LanguageTestGuard {
+    _guard: MutexGuard<'static, ()>,
+}
+
+impl Drop for LanguageTestGuard {
+    fn drop(&mut self) {
+        set_active_language(Language::English);
+    }
+}
+
+pub fn language_test_guard() -> LanguageTestGuard {
+    static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    LanguageTestGuard { _guard: LOCK.get_or_init(|| Mutex::new(())).lock().unwrap_or_else(|poisoned| poisoned.into_inner()) }
 }
 
 impl TestDir {
@@ -71,7 +88,9 @@ fn configure_user(repo: &Repository) {
 
 pub fn init_repo_at(path: &Path) -> Repository {
     fs::create_dir_all(path).unwrap();
-    let repo = Repository::init(path).unwrap();
+    let mut opts = RepositoryInitOptions::new();
+    opts.initial_head("master");
+    let repo = Repository::init_opts(path, &opts).unwrap();
     configure_user(&repo);
     repo
 }

--- a/src/helpers/branch_visibility.rs
+++ b/src/helpers/branch_visibility.rs
@@ -4,7 +4,11 @@ use im::HashSet;
 use std::{
     fs,
     path::{Path, PathBuf},
+    str,
 };
+
+const LOCAL_BRANCH_PREFIX: &[u8] = b"refs/heads/";
+const REMOTE_BRANCH_PREFIX: &[u8] = b"refs/remotes/";
 
 #[derive(Facet, Clone, Default)]
 pub struct RepositoryBranchVisibility {
@@ -50,6 +54,10 @@ pub fn current_branch_names(repo: &Repository) -> HashSet<String> {
     }
 
     names
+}
+
+pub(crate) fn branch_name_from_ref(name: &[u8]) -> Option<&str> {
+    name.strip_prefix(LOCAL_BRANCH_PREFIX).or_else(|| name.strip_prefix(REMOTE_BRANCH_PREFIX)).filter(|branch_name| !branch_name.is_empty()).and_then(|branch_name| str::from_utf8(branch_name).ok())
 }
 
 pub fn prune_hidden_branches(hidden: &mut HashSet<String>, current: &HashSet<String>) -> bool {

--- a/src/helpers/heatmap.rs
+++ b/src/helpers/heatmap.rs
@@ -79,10 +79,8 @@ fn build_heatmap_from_counts_for_day(counts: [usize; TOTAL_DAYS], today: NaiveDa
     let weekday_today = today.weekday().num_days_from_monday() as usize;
     let mut grid = [[0usize; WEEKS]; DAYS];
 
-    for (days_ago, count) in counts.into_iter().enumerate() {
-        if let Some((day_idx, week_idx)) = heatmap_cell(weekday_today, days_ago) {
-            grid[day_idx][week_idx] = count;
-        }
+    for (cell, count) in heatmap_cells(weekday_today, counts) {
+        grid[cell.day][cell.week] = count;
     }
 
     grid
@@ -112,15 +110,25 @@ fn commit_days_ago(today: NaiveDate, seconds: i64) -> Option<usize> {
     (0..TOTAL_DAYS as i64).contains(&days_ago).then_some(days_ago as usize)
 }
 
-fn heatmap_cell(weekday_today: usize, days_ago: usize) -> Option<(usize, usize)> {
+fn heatmap_cells(count_weekday: usize, counts: [usize; TOTAL_DAYS]) -> impl Iterator<Item = (HeatmapCell, usize)> {
+    counts.into_iter().enumerate().filter_map(move |(days_ago, count)| heatmap_cell(count_weekday, days_ago).map(|cell| (cell, count)))
+}
+
+fn heatmap_cell(weekday_today: usize, days_ago: usize) -> Option<HeatmapCell> {
     let offset = 6 - weekday_today;
     let logical = days_ago + offset;
     let week = logical / 7;
-    (week < WEEKS).then(|| {
-        let week_idx = WEEKS - 1 - week;
-        let day_idx = (weekday_today + 7 - (days_ago % 7)) % 7;
-        (day_idx, week_idx)
-    })
+    (week < WEEKS).then(|| HeatmapCell { day: weekday_for_age(weekday_today, days_ago), week: WEEKS - 1 - week })
+}
+
+fn weekday_for_age(weekday_today: usize, days_ago: usize) -> usize {
+    (weekday_today + DAYS - (days_ago % DAYS)) % DAYS
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+struct HeatmapCell {
+    day: usize,
+    week: usize,
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]

--- a/src/helpers/heatmap.rs
+++ b/src/helpers/heatmap.rs
@@ -1,35 +1,80 @@
-use crate::helpers::{palette::Theme, symbols::SymbolTheme};
+use crate::{
+    core::oids::Oids,
+    helpers::{palette::Theme, symbols::SymbolTheme},
+};
 use chrono::{Datelike, NaiveDate};
 use chrono::{TimeZone, Utc};
-use git2::{Oid, Repository};
-use im::HashMap;
+use gix::prelude::FindExt;
 use ratatui::{style::Style, text::Span};
 
 pub const WEEKS: usize = 53;
 pub const DAYS: usize = 7;
+const TOTAL_DAYS: usize = WEEKS * DAYS;
 
-pub fn commits_per_day(repo: &git2::Repository, oids: &Vec<Oid>) -> HashMap<usize, usize> {
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HeatmapCounts {
+    today: NaiveDate,
+    counts: [usize; TOTAL_DAYS],
+}
+
+impl Default for HeatmapCounts {
+    fn default() -> Self {
+        Self { today: Utc::now().date_naive(), counts: [0usize; TOTAL_DAYS] }
+    }
+}
+
+impl HeatmapCounts {
+    pub fn add_commit_seconds(&mut self, seconds: i64) {
+        let Some(commit_date) = Utc.timestamp_opt(seconds, 0).single().map(|date| date.date_naive()) else {
+            return;
+        };
+
+        let days_ago = self.today.signed_duration_since(commit_date).num_days();
+        if !(0..TOTAL_DAYS as i64).contains(&days_ago) {
+            return;
+        }
+
+        self.counts[days_ago as usize] += 1;
+    }
+
+    pub fn build(&self) -> [[usize; WEEKS]; DAYS] {
+        build_heatmap_from_counts_for_day(self.counts, self.today)
+    }
+}
+
+pub fn commits_per_day(repo: &gix::Repository, oids: impl IntoIterator<Item = gix::ObjectId>) -> [usize; TOTAL_DAYS] {
     // Use UTC dates so commits near midnight are bucketed consistently.
     let today: NaiveDate = Utc::now().date_naive();
-    let mut counts: HashMap<usize, usize> = HashMap::new();
+    commits_per_day_for_day(repo, oids, today)
+}
+
+fn commits_per_day_for_day(repo: &gix::Repository, oids: impl IntoIterator<Item = gix::ObjectId>, today: NaiveDate) -> [usize; TOTAL_DAYS] {
+    let mut counts = [0usize; TOTAL_DAYS];
+    let mut object_buf = Vec::new();
 
     for oid in oids {
-        let commit = match repo.find_commit(*oid) {
+        object_buf.clear();
+        let commit = match repo.objects.find_commit(oid.as_ref(), &mut object_buf) {
             Ok(c) => c,
             Err(_) => continue,
         };
 
         // Git commit times are stored as epoch seconds.
-        let commit_date = Utc.timestamp_opt(commit.time().seconds(), 0).single().unwrap().date_naive();
+        let Some(commit_date) = commit.time().ok().and_then(|time| Utc.timestamp_opt(time.seconds, 0).single()).map(|date| date.date_naive()) else {
+            continue;
+        };
 
         let days_ago = today.signed_duration_since(commit_date).num_days();
 
-        // Ignore commits outside the rendered 53-week grid.
-        if !(0..53 * 7).contains(&days_ago) {
+        if days_ago < 0 {
             continue;
         }
 
-        *counts.entry(days_ago as usize).or_insert(0) += 1;
+        if days_ago >= TOTAL_DAYS as i64 {
+            continue;
+        }
+
+        counts[days_ago as usize] += 1;
     }
 
     counts
@@ -39,24 +84,27 @@ pub fn empty_heatmap() -> [[usize; WEEKS]; DAYS] {
     [[0usize; WEEKS]; DAYS]
 }
 
-pub fn build_heatmap(repo: &Repository, oids: &Vec<Oid>) -> [[usize; WEEKS]; DAYS] {
+pub fn build_heatmap(repo: &gix::Repository, oids: impl IntoIterator<Item = gix::ObjectId>) -> [[usize; WEEKS]; DAYS] {
+    let today = Utc::now().date_naive();
+    build_heatmap_from_counts_for_day(commits_per_day_for_day(repo, oids, today), today)
+}
+
+pub fn build_heatmap_from_sorted_aliases(repo: &gix::Repository, oids: &Oids) -> [[usize; WEEKS]; DAYS] {
+    let today = Utc::now().date_naive();
+    build_heatmap_from_counts_for_day(commits_per_day_for_day(repo, oids.get_sorted_aliases().iter().map(|alias| *oids.get_oid_by_alias(*alias)), today), today)
+}
+
+fn build_heatmap_from_counts_for_day(counts: [usize; TOTAL_DAYS], today: NaiveDate) -> [[usize; WEEKS]; DAYS] {
     // Rows are weekdays starting Monday, columns run oldest to newest.
     let mut grid = [[0usize; WEEKS]; DAYS];
-
-    // Counts are keyed by days ago, with 0 representing today.
-    let counts = commits_per_day(repo, oids);
-
-    let today = Utc::now().date_naive();
 
     // Chrono uses 0 for Monday and 6 for Sunday.
     let weekday_today = today.weekday().num_days_from_monday() as usize;
 
-    let total_days = WEEKS * DAYS;
-
     // Align the newest column so today lands on its weekday row.
     let offset = 6 - weekday_today;
 
-    for days_ago in 0..total_days {
+    for (days_ago, count) in counts.iter().enumerate() {
         // Shift relative age into the displayed grid coordinate system.
         let logical = days_ago + offset;
 
@@ -72,9 +120,7 @@ pub fn build_heatmap(repo: &Repository, oids: &Vec<Oid>) -> [[usize; WEEKS]; DAY
         // Convert age back into a Monday-based weekday row.
         let day_idx = (weekday_today + 7 - (days_ago % 7)) % 7;
 
-        let count = *counts.get(&days_ago).unwrap_or(&0);
-
-        grid[day_idx][week_idx] = count;
+        grid[day_idx][week_idx] = *count;
     }
 
     grid
@@ -85,6 +131,10 @@ pub fn heat_cell(count: usize, theme: &Theme, symbols: &SymbolTheme) -> Span<'st
         0 => (symbols.heatmap.cell(count), Some(theme.COLOR_TEXT)),
         _ => (symbols.heatmap.cell(count), Some(theme.COLOR_GRASS)),
     };
-    let style = if let Some(c) = color { Style::default().fg(c) } else { Style::default() };
+    let style = color.map_or_else(Style::default, |c| Style::default().fg(c));
     Span::styled(format!("{:>2}", character), style)
 }
+
+#[cfg(test)]
+#[path = "../tests/helpers/heatmap.rs"]
+mod tests;

--- a/src/helpers/heatmap.rs
+++ b/src/helpers/heatmap.rs
@@ -72,7 +72,7 @@ pub fn build_heatmap(repo: &gix::Repository, oids: impl IntoIterator<Item = gix:
 
 pub fn build_heatmap_from_sorted_aliases(repo: &gix::Repository, oids: &Oids) -> [[usize; WEEKS]; DAYS] {
     let today = Utc::now().date_naive();
-    build_heatmap_from_counts_for_day(commits_per_day_for_day(repo, oids.get_sorted_aliases().iter().map(|alias| *oids.get_oid_by_alias(*alias)), today), today)
+    build_heatmap_from_counts_for_day(commits_per_day_for_day(repo, oids.get_sorted_aliases().iter().map(|alias| *oids.get_gix_oid_by_alias(*alias)), today), today)
 }
 
 fn build_heatmap_from_counts_for_day(counts: [usize; TOTAL_DAYS], today: NaiveDate) -> [[usize; WEEKS]; DAYS] {

--- a/src/helpers/heatmap.rs
+++ b/src/helpers/heatmap.rs
@@ -25,16 +25,9 @@ impl Default for HeatmapCounts {
 
 impl HeatmapCounts {
     pub fn add_commit_seconds(&mut self, seconds: i64) {
-        let Some(commit_date) = Utc.timestamp_opt(seconds, 0).single().map(|date| date.date_naive()) else {
-            return;
-        };
-
-        let days_ago = self.today.signed_duration_since(commit_date).num_days();
-        if !(0..TOTAL_DAYS as i64).contains(&days_ago) {
-            return;
+        if let Some(days_ago) = commit_days_ago(self.today, seconds) {
+            self.counts[days_ago] += 1;
         }
-
-        self.counts[days_ago as usize] += 1;
     }
 
     pub fn build(&self) -> [[usize; WEEKS]; DAYS] {
@@ -54,27 +47,15 @@ fn commits_per_day_for_day(repo: &gix::Repository, oids: impl IntoIterator<Item 
 
     for oid in oids {
         object_buf.clear();
-        let commit = match repo.objects.find_commit(oid.as_ref(), &mut object_buf) {
-            Ok(c) => c,
-            Err(_) => continue,
-        };
-
-        // Git commit times are stored as epoch seconds.
-        let Some(commit_date) = commit.time().ok().and_then(|time| Utc.timestamp_opt(time.seconds, 0).single()).map(|date| date.date_naive()) else {
+        let Some(commit_date) = commit_date(repo, &oid, &mut object_buf) else {
             continue;
         };
 
-        let days_ago = today.signed_duration_since(commit_date).num_days();
-
-        if days_ago < 0 {
-            continue;
+        match bucket_date(today, commit_date) {
+            DateBucket::Count(days_ago) => counts[days_ago] += 1,
+            DateBucket::Future => continue,
+            DateBucket::BeforeWindow => continue,
         }
-
-        if days_ago >= TOTAL_DAYS as i64 {
-            continue;
-        }
-
-        counts[days_ago as usize] += 1;
     }
 
     counts
@@ -95,35 +76,58 @@ pub fn build_heatmap_from_sorted_aliases(repo: &gix::Repository, oids: &Oids) ->
 }
 
 fn build_heatmap_from_counts_for_day(counts: [usize; TOTAL_DAYS], today: NaiveDate) -> [[usize; WEEKS]; DAYS] {
-    // Rows are weekdays starting Monday, columns run oldest to newest.
+    let weekday_today = today.weekday().num_days_from_monday() as usize;
     let mut grid = [[0usize; WEEKS]; DAYS];
 
-    // Chrono uses 0 for Monday and 6 for Sunday.
-    let weekday_today = today.weekday().num_days_from_monday() as usize;
-
-    // Align the newest column so today lands on its weekday row.
-    let offset = 6 - weekday_today;
-
-    for (days_ago, count) in counts.iter().enumerate() {
-        // Shift relative age into the displayed grid coordinate system.
-        let logical = days_ago + offset;
-
-        let week = logical / 7;
-
-        if week >= WEEKS {
-            continue;
+    for (days_ago, count) in counts.into_iter().enumerate() {
+        if let Some((day_idx, week_idx)) = heatmap_cell(weekday_today, days_ago) {
+            grid[day_idx][week_idx] = count;
         }
-
-        // Reverse week order because the screen reads oldest to newest.
-        let week_idx = WEEKS - 1 - week;
-
-        // Convert age back into a Monday-based weekday row.
-        let day_idx = (weekday_today + 7 - (days_ago % 7)) % 7;
-
-        grid[day_idx][week_idx] = *count;
     }
 
     grid
+}
+
+fn commit_date(repo: &gix::Repository, oid: &gix::ObjectId, object_buf: &mut Vec<u8>) -> Option<NaiveDate> {
+    let commit = repo.objects.find_commit(oid, object_buf).ok()?;
+    Utc.timestamp_opt(commit.time().ok()?.seconds, 0).single().map(|date| date.date_naive())
+}
+
+fn bucket_date(today: NaiveDate, commit_date: NaiveDate) -> DateBucket {
+    let days_ago = today.signed_duration_since(commit_date).num_days();
+
+    if days_ago < 0 {
+        DateBucket::Future
+    } else if days_ago >= TOTAL_DAYS as i64 {
+        DateBucket::BeforeWindow
+    } else {
+        DateBucket::Count(days_ago as usize)
+    }
+}
+
+fn commit_days_ago(today: NaiveDate, seconds: i64) -> Option<usize> {
+    let commit_date = Utc.timestamp_opt(seconds, 0).single()?.date_naive();
+    let days_ago = today.signed_duration_since(commit_date).num_days();
+
+    (0..TOTAL_DAYS as i64).contains(&days_ago).then_some(days_ago as usize)
+}
+
+fn heatmap_cell(weekday_today: usize, days_ago: usize) -> Option<(usize, usize)> {
+    let offset = 6 - weekday_today;
+    let logical = days_ago + offset;
+    let week = logical / 7;
+    (week < WEEKS).then(|| {
+        let week_idx = WEEKS - 1 - week;
+        let day_idx = (weekday_today + 7 - (days_ago % 7)) % 7;
+        (day_idx, week_idx)
+    })
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum DateBucket {
+    Count(usize),
+    Future,
+    BeforeWindow,
 }
 
 pub fn heat_cell(count: usize, theme: &Theme, symbols: &SymbolTheme) -> Span<'static> {

--- a/src/helpers/heatmap.rs
+++ b/src/helpers/heatmap.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use chrono::{Datelike, NaiveDate};
 use chrono::{TimeZone, Utc};
-use gix::prelude::FindExt;
+use git2::{Oid, Repository};
 use ratatui::{style::Style, text::Span};
 
 pub const WEEKS: usize = 53;
@@ -35,19 +35,17 @@ impl HeatmapCounts {
     }
 }
 
-pub fn commits_per_day(repo: &gix::Repository, oids: impl IntoIterator<Item = gix::ObjectId>) -> [usize; TOTAL_DAYS] {
+pub fn commits_per_day(repo: &Repository, oids: impl IntoIterator<Item = Oid>) -> [usize; TOTAL_DAYS] {
     // Use UTC dates so commits near midnight are bucketed consistently.
     let today: NaiveDate = Utc::now().date_naive();
     commits_per_day_for_day(repo, oids, today)
 }
 
-fn commits_per_day_for_day(repo: &gix::Repository, oids: impl IntoIterator<Item = gix::ObjectId>, today: NaiveDate) -> [usize; TOTAL_DAYS] {
+fn commits_per_day_for_day(repo: &Repository, oids: impl IntoIterator<Item = Oid>, today: NaiveDate) -> [usize; TOTAL_DAYS] {
     let mut counts = [0usize; TOTAL_DAYS];
-    let mut object_buf = Vec::new();
 
     for oid in oids {
-        object_buf.clear();
-        let Some(commit_date) = commit_date(repo, &oid, &mut object_buf) else {
+        let Some(commit_date) = commit_date(repo, oid) else {
             continue;
         };
 
@@ -65,14 +63,14 @@ pub fn empty_heatmap() -> [[usize; WEEKS]; DAYS] {
     [[0usize; WEEKS]; DAYS]
 }
 
-pub fn build_heatmap(repo: &gix::Repository, oids: impl IntoIterator<Item = gix::ObjectId>) -> [[usize; WEEKS]; DAYS] {
+pub fn build_heatmap(repo: &Repository, oids: impl IntoIterator<Item = Oid>) -> [[usize; WEEKS]; DAYS] {
     let today = Utc::now().date_naive();
     build_heatmap_from_counts_for_day(commits_per_day_for_day(repo, oids, today), today)
 }
 
-pub fn build_heatmap_from_sorted_aliases(repo: &gix::Repository, oids: &Oids) -> [[usize; WEEKS]; DAYS] {
+pub fn build_heatmap_from_sorted_aliases(repo: &Repository, oids: &Oids) -> [[usize; WEEKS]; DAYS] {
     let today = Utc::now().date_naive();
-    build_heatmap_from_counts_for_day(commits_per_day_for_day(repo, oids.get_sorted_aliases().iter().map(|alias| *oids.get_gix_oid_by_alias(*alias)), today), today)
+    build_heatmap_from_counts_for_day(commits_per_day_for_day(repo, oids.get_sorted_aliases().iter().map(|alias| oids.get_oid_by_alias(*alias)), today), today)
 }
 
 fn build_heatmap_from_counts_for_day(counts: [usize; TOTAL_DAYS], today: NaiveDate) -> [[usize; WEEKS]; DAYS] {
@@ -86,9 +84,9 @@ fn build_heatmap_from_counts_for_day(counts: [usize; TOTAL_DAYS], today: NaiveDa
     grid
 }
 
-fn commit_date(repo: &gix::Repository, oid: &gix::ObjectId, object_buf: &mut Vec<u8>) -> Option<NaiveDate> {
-    let commit = repo.objects.find_commit(oid, object_buf).ok()?;
-    Utc.timestamp_opt(commit.time().ok()?.seconds, 0).single().map(|date| date.date_naive())
+fn commit_date(repo: &Repository, oid: Oid) -> Option<NaiveDate> {
+    let commit = repo.find_commit(oid).ok()?;
+    Utc.timestamp_opt(commit.time().seconds(), 0).single().map(|date| date.date_naive())
 }
 
 fn bucket_date(today: NaiveDate, commit_date: NaiveDate) -> DateBucket {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod core {
 }
 pub mod git {
     pub mod auth;
+    pub mod gix;
     pub mod actions {
         pub mod branching;
         pub mod checkout;
@@ -37,6 +38,8 @@ pub mod git {
         pub mod tagging;
         pub mod worktrees;
     }
+    #[cfg(test)]
+    pub mod test_support;
     pub mod os {
         pub mod path;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,8 @@ pub mod core {
 pub mod git {
     pub mod auth;
     pub mod gix;
+    #[cfg(test)]
+    pub mod test_support;
     pub mod actions {
         pub mod branching;
         pub mod checkout;
@@ -38,8 +40,6 @@ pub mod git {
         pub mod tagging;
         pub mod worktrees;
     }
-    #[cfg(test)]
-    pub mod test_support;
     pub mod os {
         pub mod path;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,6 @@ use guitar::{App, VERSION};
 
 const RESET_CONFIG: &str = "--reset";
 const EXIT_WHEN_GRAPH_COMPLETE: &str = "--exit-when-graph-complete";
-const SKIP_WORKDIR_STATUS: &str = "--skip-workdir-status";
 const VERSION_LONG: &str = "--version";
 const VERSION_SHORT: &str = "-v";
 
@@ -44,12 +43,10 @@ fn main() -> io::Result<()> {
     }
 
     let exit_when_graph_complete = args.iter().any(|a| a == EXIT_WHEN_GRAPH_COMPLETE);
-    let skip_workdir_status = args.iter().any(|a| a == SKIP_WORKDIR_STATUS);
     let repo_path = repo_path_from_args(&args);
 
     if exit_when_graph_complete {
         let mut app = App::default();
-        app.skip_workdir_status = true;
         app.bootstrap(repo_path);
         let result = app.wait_until_graph_complete(std::time::Duration::from_secs(600));
         app.shutdown_background_tasks();
@@ -58,7 +55,6 @@ fn main() -> io::Result<()> {
     }
 
     let mut app = App::default();
-    app.skip_workdir_status = skip_workdir_status;
     if let Some(path) = repo_path {
         app.path = Some(path);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,8 +3,14 @@ use std::{env, fs, io, path::PathBuf};
 use guitar::{App, VERSION};
 
 const RESET_CONFIG: &str = "--reset";
+const EXIT_WHEN_GRAPH_COMPLETE: &str = "--exit-when-graph-complete";
+const SKIP_WORKDIR_STATUS: &str = "--skip-workdir-status";
 const VERSION_LONG: &str = "--version";
 const VERSION_SHORT: &str = "-v";
+
+fn repo_path_from_args(args: &[String]) -> Option<String> {
+    args.iter().skip(1).find(|arg| !arg.starts_with('-')).cloned()
+}
 
 fn guitar_config_dir() -> io::Result<PathBuf> {
     let mut path = dirs::config_dir().ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, "Could not find config directory"))?;
@@ -37,8 +43,28 @@ fn main() -> io::Result<()> {
         reset_saved_config()?;
     }
 
+    let exit_when_graph_complete = args.iter().any(|a| a == EXIT_WHEN_GRAPH_COMPLETE);
+    let skip_workdir_status = args.iter().any(|a| a == SKIP_WORKDIR_STATUS);
+    let repo_path = repo_path_from_args(&args);
+
+    if exit_when_graph_complete {
+        let mut app = App::default();
+        app.skip_workdir_status = true;
+        app.bootstrap(repo_path);
+        let result = app.wait_until_graph_complete(std::time::Duration::from_secs(600));
+        app.shutdown_background_tasks();
+        println!("{}", result?);
+        return Ok(());
+    }
+
+    let mut app = App::default();
+    app.skip_workdir_status = skip_workdir_status;
+    if let Some(path) = repo_path {
+        app.path = Some(path);
+    }
+
     let mut terminal = ratatui::init();
-    let app_result = App::default().run(&mut terminal);
+    let app_result = app.run(&mut terminal);
     ratatui::restore();
     app_result
 }

--- a/src/tests/app/draw/settings.rs
+++ b/src/tests/app/draw/settings.rs
@@ -142,6 +142,8 @@ fn settings_active_tabs_render_their_grouped_sections_only() {
 
 #[test]
 fn settings_shortcuts_render_graph_lane_limit_shortcuts() {
+    let _guard = crate::git::test_support::language_test_guard();
+
     crate::helpers::localisation::set_active_language(Language::English);
     let (_path, repo) = temp_repo("lane-limit-shortcuts");
     let mut app = settings_app();

--- a/src/tests/app/input/git.rs
+++ b/src/tests/app/input/git.rs
@@ -21,12 +21,7 @@ fn temp_repo(name: &str) -> (std::path::PathBuf, Repository) {
     let id = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
     let path = std::env::temp_dir().join(format!("guitar-input-git-{name}-{id}"));
     fs::create_dir_all(&path).unwrap();
-    let repo = Repository::init(&path).unwrap();
-    {
-        let mut config = repo.config().unwrap();
-        config.set_str("user.name", "Test User").unwrap();
-        config.set_str("user.email", "test@example.com").unwrap();
-    }
+    let repo = crate::git::test_support::init_repo_at(&path);
     (path, repo)
 }
 

--- a/src/tests/app/input/navigation.rs
+++ b/src/tests/app/input/navigation.rs
@@ -1098,6 +1098,8 @@ fn settings_symbol_theme_selection_updates_persists_and_stays_in_settings() {
 
 #[test]
 fn settings_language_selection_updates_persists_and_stays_in_settings() {
+    let _guard = crate::git::test_support::language_test_guard();
+
     let path = temp_language_path("select");
     let mut app = App {
         viewport: Viewport::Settings,
@@ -1117,8 +1119,6 @@ fn settings_language_selection_updates_persists_and_stays_in_settings() {
     assert_eq!(app.settings_selected, 12);
     assert_eq!(app.settings_scroll.get(), 4);
     assert_eq!(fs::read_to_string(path).unwrap(), "\"spanish\"");
-
-    crate::helpers::localisation::set_active_language(Language::English);
 }
 
 #[test]

--- a/src/tests/app/input/navigation.rs
+++ b/src/tests/app/input/navigation.rs
@@ -69,12 +69,7 @@ fn temp_repo(name: &str) -> (std::path::PathBuf, Repository) {
     let id = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
     let path = std::env::temp_dir().join(format!("guitar-input-navigation-{name}-{id}"));
     fs::create_dir_all(&path).unwrap();
-    let repo = Repository::init(&path).unwrap();
-    {
-        let mut config = repo.config().unwrap();
-        config.set_str("user.name", "Test User").unwrap();
-        config.set_str("user.email", "test@example.com").unwrap();
-    }
+    let repo = crate::git::test_support::init_repo_at(&path);
     (path, repo)
 }
 

--- a/src/tests/app/state/app.rs
+++ b/src/tests/app/state/app.rs
@@ -400,7 +400,6 @@ fn wait_until_graph_complete_returns_commit_count_when_graph_finishes() {
     let count = app.wait_until_graph_complete(std::time::Duration::from_secs(1)).unwrap();
 
     assert_eq!(count, 4);
-    assert!(app.skip_workdir_status);
     assert!(app.graph.is_complete);
 }
 
@@ -420,29 +419,6 @@ fn wait_until_graph_complete_returns_error_when_modal_error_is_set() {
     assert_eq!(error.kind(), io::ErrorKind::Other);
     assert!(error.to_string().contains("graph walk failed"));
 }
-
-#[test]
-fn skip_workdir_status_on_first_progress_leaves_modal_error_empty_on_bare_repo() {
-    let id = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
-    let path = std::env::temp_dir().join(format!("guitar-app-state-bare-{id}"));
-    let bare = Repository::init_bare(&path).unwrap();
-    let repo = Rc::new(bare);
-    let (event_tx, event_rx) = std::sync::mpsc::channel();
-    let mut app = App { repo: Some(repo.clone()), graph_rx: Some(event_rx), viewport: Viewport::Splash, focus: Focus::Viewport, skip_workdir_status: true, ..Default::default() };
-    app.graph.generation = 13;
-
-    event_tx.send(GraphEvent::Progress { generation: 13, version: 1, total: 0, is_first: true, is_complete: false }).unwrap();
-    app.sync(&repo);
-
-    assert_eq!(app.viewport, Viewport::Graph);
-    assert!(app.is_uncommitted_loaded);
-    assert!(app.modal_error_message.is_empty());
-    assert!(app.uncommitted.unstaged.added.is_empty());
-    assert!(app.uncommitted.staged.added.is_empty());
-
-    let _ = fs::remove_dir_all(path);
-}
-
 #[test]
 fn wait_until_graph_complete_returns_error_before_success_when_both_are_set() {
     let (_path, repo) = temp_repo("graph-complete-error-wins");

--- a/src/tests/app/state/app.rs
+++ b/src/tests/app/state/app.rs
@@ -4,7 +4,7 @@ use crate::git::queries::helpers::FileStatus;
 use git2::{Repository, Signature};
 use ratatui::{Terminal, backend::TestBackend, layout::Rect, style::Color};
 use std::{
-    fs,
+    fs, io,
     path::{Path, PathBuf},
     process,
     rc::Rc,
@@ -384,4 +384,94 @@ fn pane_window_request_reuses_cached_window_that_covers_range() {
         },
         other => panic!("expected pane window request, got {other:?}"),
     }
+}
+
+#[test]
+fn wait_until_graph_complete_returns_commit_count_when_graph_finishes() {
+    let (_path, repo) = temp_repo("graph-complete-wait");
+    let repo = Rc::new(repo);
+    let (event_tx, event_rx) = std::sync::mpsc::channel();
+    let mut app = App { repo: Some(repo.clone()), graph_rx: Some(event_rx), viewport: Viewport::Graph, focus: Focus::Viewport, ..Default::default() };
+    app.graph.generation = 11;
+
+    event_tx.send(GraphEvent::Progress { generation: 11, version: 1, total: 4, is_first: true, is_complete: false }).unwrap();
+    event_tx.send(GraphEvent::Progress { generation: 11, version: 2, total: 4, is_first: false, is_complete: true }).unwrap();
+
+    let count = app.wait_until_graph_complete(std::time::Duration::from_secs(1)).unwrap();
+
+    assert_eq!(count, 4);
+    assert!(app.skip_workdir_status);
+    assert!(app.graph.is_complete);
+}
+
+#[test]
+fn wait_until_graph_complete_returns_error_when_modal_error_is_set() {
+    let (_path, repo) = temp_repo("graph-complete-error");
+    let repo = Rc::new(repo);
+    let (event_tx, event_rx) = std::sync::mpsc::channel();
+    let mut app = App { repo: Some(repo.clone()), graph_rx: Some(event_rx), viewport: Viewport::Graph, focus: Focus::Viewport, ..Default::default() };
+    app.graph.generation = 12;
+
+    event_tx.send(GraphEvent::Progress { generation: 12, version: 1, total: 1, is_first: true, is_complete: false }).unwrap();
+    app.modal_error_message = "graph walk failed".into();
+
+    let error = app.wait_until_graph_complete(std::time::Duration::from_secs(1)).unwrap_err();
+
+    assert_eq!(error.kind(), io::ErrorKind::Other);
+    assert!(error.to_string().contains("graph walk failed"));
+}
+
+#[test]
+fn skip_workdir_status_on_first_progress_leaves_modal_error_empty_on_bare_repo() {
+    let id = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+    let path = std::env::temp_dir().join(format!("guitar-app-state-bare-{id}"));
+    let bare = Repository::init_bare(&path).unwrap();
+    let repo = Rc::new(bare);
+    let (event_tx, event_rx) = std::sync::mpsc::channel();
+    let mut app = App { repo: Some(repo.clone()), graph_rx: Some(event_rx), viewport: Viewport::Splash, focus: Focus::Viewport, skip_workdir_status: true, ..Default::default() };
+    app.graph.generation = 13;
+
+    event_tx.send(GraphEvent::Progress { generation: 13, version: 1, total: 0, is_first: true, is_complete: false }).unwrap();
+    app.sync(&repo);
+
+    assert_eq!(app.viewport, Viewport::Graph);
+    assert!(app.is_uncommitted_loaded);
+    assert!(app.modal_error_message.is_empty());
+    assert!(app.uncommitted.unstaged.added.is_empty());
+    assert!(app.uncommitted.staged.added.is_empty());
+
+    let _ = fs::remove_dir_all(path);
+}
+
+#[test]
+fn wait_until_graph_complete_returns_error_before_success_when_both_are_set() {
+    let (_path, repo) = temp_repo("graph-complete-error-wins");
+    let repo = Rc::new(repo);
+    let (event_tx, event_rx) = std::sync::mpsc::channel();
+    let mut app = App { repo: Some(repo.clone()), graph_rx: Some(event_rx), viewport: Viewport::Graph, focus: Focus::Viewport, ..Default::default() };
+    app.graph.generation = 13;
+
+    event_tx.send(GraphEvent::Progress { generation: 13, version: 1, total: 1, is_first: true, is_complete: true }).unwrap();
+    app.modal_error_message = "graph walk failed".into();
+
+    let error = app.wait_until_graph_complete(std::time::Duration::from_secs(1)).unwrap_err();
+
+    assert_eq!(error.kind(), io::ErrorKind::Other);
+    assert!(error.to_string().contains("graph walk failed"));
+}
+
+#[test]
+fn wait_until_graph_complete_returns_error_when_graph_worker_disconnects() {
+    let (_path, repo) = temp_repo("graph-complete-disconnect");
+    let repo = Rc::new(repo);
+    let (event_tx, event_rx) = std::sync::mpsc::channel();
+    let mut app = App { repo: Some(repo.clone()), graph_rx: Some(event_rx), viewport: Viewport::Graph, focus: Focus::Viewport, ..Default::default() };
+    app.graph.generation = 14;
+
+    drop(event_tx);
+
+    let error = app.wait_until_graph_complete(std::time::Duration::from_secs(1)).unwrap_err();
+
+    assert_eq!(error.kind(), io::ErrorKind::BrokenPipe);
+    assert!(error.to_string().contains("graph worker disconnected"));
 }

--- a/src/tests/core/graph_service.rs
+++ b/src/tests/core/graph_service.rs
@@ -13,12 +13,7 @@ fn temp_repo(name: &str) -> (PathBuf, Repository) {
     let id = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
     let path = std::env::temp_dir().join(format!("guitar-graph-service-{name}-{id}"));
     fs::create_dir_all(&path).unwrap();
-    let repo = Repository::init(&path).unwrap();
-    {
-        let mut config = repo.config().unwrap();
-        config.set_str("user.name", "Test User").unwrap();
-        config.set_str("user.email", "test@example.com").unwrap();
-    }
+    let repo = crate::git::test_support::init_repo_at(&path);
     (path, repo)
 }
 

--- a/src/tests/core/graph_service.rs
+++ b/src/tests/core/graph_service.rs
@@ -1,339 +1,242 @@
 use super::*;
+use crate::git::test_support::{commit_file, temp_repo};
 use crate::helpers::symbols::SymbolTheme;
-use git2::{Oid, Repository, Signature, build::CheckoutBuilder};
+use git2::build::CheckoutBuilder;
 use im::HashSet;
 use std::{
-    fs,
-    path::{Path, PathBuf},
-    sync::{Arc, atomic::AtomicBool, mpsc::channel},
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    path::PathBuf,
+    sync::{
+        Arc,
+        atomic::AtomicBool,
+        mpsc::{Receiver, Sender, channel},
+    },
+    time::Duration,
 };
 
-fn temp_repo(name: &str) -> (PathBuf, Repository) {
-    let id = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
-    let path = std::env::temp_dir().join(format!("guitar-graph-service-{name}-{id}"));
-    fs::create_dir_all(&path).unwrap();
-    let repo = Repository::init(&path).unwrap();
-    {
-        let mut config = repo.config().unwrap();
-        config.set_str("user.name", "Test User").unwrap();
-        config.set_str("user.email", "test@example.com").unwrap();
-    }
-    (path, repo)
+struct GraphServiceHarness {
+    generation: u64,
+    cmd_tx: Sender<GraphCommand>,
+    event_rx: Receiver<GraphEvent>,
+    cancel: Arc<AtomicBool>,
+    handle: std::thread::JoinHandle<()>,
 }
 
-fn commit(repo: &Repository, file: &str, message: &str) -> Oid {
-    let workdir = repo.workdir().unwrap().to_path_buf();
-    fs::write(workdir.join(file), message).unwrap();
+impl GraphServiceHarness {
+    fn spawn(path: PathBuf, generation: u64, amount: usize, hidden_branch_names: HashSet<String>, include_head_reflog_roots: bool, worktrees: Vec<WorktreeEntry>) -> Self {
+        let (cmd_tx, cmd_rx) = channel();
+        let (event_tx, event_rx) = channel();
+        let cancel = Arc::new(AtomicBool::new(false));
+        let handle = spawn_graph_service(
+            GraphServiceConfig { generation, path: path.display().to_string(), amount, hidden_branch_names, include_head_reflog_roots, graph_lane_limit: 20, worktrees, symbols: SymbolTheme::main() },
+            cmd_rx,
+            event_tx,
+            cancel.clone(),
+        );
 
-    let mut index = repo.index().unwrap();
-    index.add_path(Path::new(file)).unwrap();
-    index.write().unwrap();
-    let tree_oid = index.write_tree().unwrap();
-    let tree = repo.find_tree(tree_oid).unwrap();
-    let sig = Signature::now("Test User", "test@example.com").unwrap();
-    let parent = repo.head().ok().and_then(|head| head.peel_to_commit().ok());
-    let parents: Vec<&git2::Commit<'_>> = parent.iter().collect();
-    repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &parents).unwrap()
+        Self { generation, cmd_tx, event_rx, cancel, handle }
+    }
+
+    fn wait_for_progress(&self, is_complete: bool) -> usize {
+        for _ in 0..20 {
+            match self.event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
+                GraphEvent::Progress { generation, total, is_complete: event_complete, .. } if generation == self.generation && event_complete == is_complete => {
+                    return total;
+                },
+                _ => {},
+            }
+        }
+        panic!("timed out waiting for graph service progress");
+    }
+
+    fn wait_for_window(&self, request_id: u64) -> (Vec<GraphRow>, GraphHistory, usize) {
+        for _ in 0..20 {
+            match self.event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
+                GraphEvent::GraphWindow { generation, request_id: event_request_id, rows, history, total, .. } if generation == self.generation && event_request_id == request_id => {
+                    return (rows, history, total);
+                },
+                _ => {},
+            }
+        }
+        panic!("timed out waiting for graph window");
+    }
+
+    fn wait_for_lookup(&self, request_id: u64) -> GraphLookupResult {
+        for _ in 0..20 {
+            match self.event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
+                GraphEvent::LookupResult { generation, request_id: event_request_id, result, .. } if generation == self.generation && event_request_id == request_id => {
+                    return result;
+                },
+                _ => {},
+            }
+        }
+        panic!("timed out waiting for lookup result");
+    }
+
+    fn wait_for_worktrees(&self) -> (u64, Vec<WorktreeEntry>) {
+        for _ in 0..20 {
+            match self.event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
+                GraphEvent::Worktrees { generation, version, worktrees } if generation == self.generation => {
+                    return (version, worktrees);
+                },
+                _ => {},
+            }
+        }
+        panic!("timed out waiting for worktree update");
+    }
+
+    fn wait_for_pane_window(&self, pane: GraphPane) -> Vec<GraphPaneRow> {
+        for _ in 0..20 {
+            match self.event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
+                GraphEvent::PaneWindow { generation, pane: event_pane, rows, .. } if generation == self.generation && event_pane == pane => {
+                    return rows;
+                },
+                _ => {},
+            }
+        }
+        panic!("timed out waiting for pane window");
+    }
+
+    fn wait_for_file_history(&self, request_id: u64) -> (String, Vec<GraphFileHistoryRow>, Option<String>) {
+        for _ in 0..20 {
+            match self.event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
+                GraphEvent::FileHistory { generation, request_id: event_request_id, path, rows, error } if generation == self.generation && event_request_id == request_id => {
+                    return (path, rows, error);
+                },
+                _ => {},
+            }
+        }
+        panic!("timed out waiting for file history");
+    }
+
+    fn send(&self, command: GraphCommand) {
+        self.cmd_tx.send(command).unwrap();
+    }
+
+    fn shutdown(self) {
+        let _ = self.cmd_tx.send(GraphCommand::Shutdown);
+        self.cancel.store(true, std::sync::atomic::Ordering::SeqCst);
+        self.handle.join().unwrap();
+    }
 }
 
 #[test]
 fn graph_service_reports_progress_and_answers_visible_window() {
-    let (path, repo) = temp_repo("window");
-    commit(&repo, "one.txt", "one");
-    let two = commit(&repo, "two.txt", "two");
+    let (dir, repo) = temp_repo("window");
+    let path = dir.join("repo");
+    commit_file(&repo, "one.txt", "one", "one");
+    let two = commit_file(&repo, "two.txt", "two", "two");
+    let harness = GraphServiceHarness::spawn(path.clone(), 42, 1, HashSet::new(), false, Vec::new());
 
-    let generation = 42;
-    let (cmd_tx, cmd_rx) = channel();
-    let (event_tx, event_rx) = channel();
-    let cancel = Arc::new(AtomicBool::new(false));
-    let handle = spawn_graph_service(
-        GraphServiceConfig {
-            generation,
-            path: path.display().to_string(),
-            amount: 1,
-            hidden_branch_names: HashSet::new(),
-            include_head_reflog_roots: false,
-            graph_lane_limit: 20,
-            worktrees: Vec::new(),
-            symbols: SymbolTheme::main(),
-        },
-        cmd_rx,
-        event_tx,
-        cancel.clone(),
-    );
+    assert!(harness.wait_for_progress(false) > 0);
 
-    let mut saw_progress = false;
-    for _ in 0..20 {
-        match event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
-            GraphEvent::Progress { generation: event_generation, total, .. } if event_generation == generation => {
-                saw_progress = true;
-                assert!(total > 0);
-                break;
-            },
-            _ => {},
-        }
-    }
-    assert!(saw_progress);
+    harness.send(GraphCommand::QueryGraphWindow { generation: 42, request_id: 7, start: 0, end: 2 });
+    let (rows, history, total) = harness.wait_for_window(7);
+    assert!(total >= rows.len());
+    assert!(!rows.is_empty());
+    assert!(!history.is_empty());
+    assert!(rows.len() <= 2);
 
-    cmd_tx.send(GraphCommand::QueryGraphWindow { generation, request_id: 7, start: 0, end: 2 }).unwrap();
+    harness.send(GraphCommand::Lookup { generation: 42, request_id: 8, kind: GraphLookupKind::ShaPrefix { prefix: two.to_string()[..8].to_string() } });
+    assert!(matches!(harness.wait_for_lookup(8), GraphLookupResult::Index(Some(_))));
 
-    let mut saw_window = false;
-    for _ in 0..20 {
-        match event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
-            GraphEvent::GraphWindow { generation: event_generation, request_id, rows, history, total, .. } if event_generation == generation && request_id == 7 => {
-                saw_window = true;
-                assert!(total >= rows.len());
-                assert!(!rows.is_empty());
-                assert!(!history.is_empty());
-                assert!(rows.len() <= 2);
-                break;
-            },
-            _ => {},
-        }
-    }
-    assert!(saw_window);
+    harness.send(GraphCommand::Lookup { generation: 42, request_id: 9, kind: GraphLookupKind::Oid { oid: two } });
+    assert!(matches!(harness.wait_for_lookup(9), GraphLookupResult::Index(Some(1))));
 
-    cmd_tx.send(GraphCommand::Lookup { generation, request_id: 8, kind: GraphLookupKind::ShaPrefix { prefix: two.to_string()[..8].to_string() } }).unwrap();
+    let updated = vec![WorktreeEntry {
+        name: "repo".to_string(),
+        path,
+        branch: Some("master".to_string()),
+        head: Some(two),
+        alias: None,
+        kind: crate::core::worktrees::WorktreeKind::Main,
+        is_current: true,
+        is_valid: true,
+        is_prunable: false,
+        locked_reason: None,
+        is_dirty: true,
+    }];
+    harness.send(GraphCommand::UpdateWorktrees { generation: 42, worktrees: updated.clone() });
+    let (_, worktrees) = harness.wait_for_worktrees();
+    assert_eq!(worktrees, updated);
 
-    let mut saw_lookup = false;
-    for _ in 0..20 {
-        match event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
-            GraphEvent::LookupResult { generation: event_generation, request_id, result: GraphLookupResult::Index(Some(_)), .. } if event_generation == generation && request_id == 8 => {
-                saw_lookup = true;
-                break;
-            },
-            _ => {},
-        }
-    }
-    assert!(saw_lookup);
-
-    cmd_tx.send(GraphCommand::Lookup { generation, request_id: 9, kind: GraphLookupKind::Oid { oid: two } }).unwrap();
-
-    let mut saw_oid_lookup = false;
-    for _ in 0..20 {
-        match event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
-            GraphEvent::LookupResult { generation: event_generation, request_id, result: GraphLookupResult::Index(Some(index)), .. } if event_generation == generation && request_id == 9 => {
-                saw_oid_lookup = true;
-                assert_eq!(index, 1);
-                break;
-            },
-            _ => {},
-        }
-    }
-    assert!(saw_oid_lookup);
-
-    let _ = cmd_tx.send(GraphCommand::Shutdown);
-    cancel.store(true, std::sync::atomic::Ordering::SeqCst);
-    handle.join().unwrap();
+    harness.shutdown();
 }
 
 #[test]
 fn graph_service_file_history_returns_visible_graph_indices() {
-    let (path, repo) = temp_repo("file-history");
-    let first = commit(&repo, "target.txt", "first");
-    commit(&repo, "other.txt", "other");
-    let latest = commit(&repo, "target.txt", "latest");
+    let (dir, repo) = temp_repo("file-history");
+    let path = dir.join("repo");
+    let first = commit_file(&repo, "target.txt", "first", "first");
+    commit_file(&repo, "other.txt", "other", "other");
+    let latest = commit_file(&repo, "target.txt", "latest", "latest");
+    let harness = GraphServiceHarness::spawn(path, 77, 10000, HashSet::new(), false, Vec::new());
 
-    let generation = 77;
-    let (cmd_tx, cmd_rx) = channel();
-    let (event_tx, event_rx) = channel();
-    let cancel = Arc::new(AtomicBool::new(false));
-    let handle = spawn_graph_service(
-        GraphServiceConfig {
-            generation,
-            path: path.display().to_string(),
-            amount: 10000,
-            hidden_branch_names: HashSet::new(),
-            include_head_reflog_roots: false,
-            graph_lane_limit: 20,
-            worktrees: Vec::new(),
-            symbols: SymbolTheme::main(),
-        },
-        cmd_rx,
-        event_tx,
-        cancel.clone(),
-    );
+    assert!(harness.wait_for_progress(true) > 0);
 
-    let mut complete = false;
-    for _ in 0..20 {
-        match event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
-            GraphEvent::Progress { generation: event_generation, is_complete, .. } if event_generation == generation && is_complete => {
-                complete = true;
-                break;
-            },
-            _ => {},
-        }
-    }
-    assert!(complete);
+    harness.send(GraphCommand::QueryFileHistory { generation: 78, request_id: 41, path: "target.txt".to_string() });
+    harness.send(GraphCommand::QueryFileHistory { generation: 77, request_id: 42, path: "target.txt".to_string() });
 
-    cmd_tx.send(GraphCommand::QueryFileHistory { generation: generation + 1, request_id: 41, path: "target.txt".to_string() }).unwrap();
-    cmd_tx.send(GraphCommand::QueryFileHistory { generation, request_id: 42, path: "target.txt".to_string() }).unwrap();
+    let (path, rows, error) = harness.wait_for_file_history(42);
+    assert_eq!(path, "target.txt");
+    assert_eq!(error, None);
+    assert_eq!(rows.iter().map(|row| row.graph_index).collect::<Vec<_>>(), vec![1, 3]);
+    assert_eq!(rows.iter().map(|row| row.oid).collect::<Vec<_>>(), vec![latest, first]);
 
-    let mut saw_history = false;
-    for _ in 0..20 {
-        match event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
-            GraphEvent::FileHistory { generation: event_generation, request_id, path, rows, error } if event_generation == generation && request_id == 42 => {
-                saw_history = true;
-                assert_eq!(path, "target.txt");
-                assert_eq!(error, None);
-                assert_eq!(rows.iter().map(|row| row.graph_index).collect::<Vec<_>>(), vec![1, 3]);
-                assert_eq!(rows.iter().map(|row| row.oid).collect::<Vec<_>>(), vec![latest, first]);
-                break;
-            },
-            GraphEvent::FileHistory { request_id: 41, .. } => panic!("stale generation should not produce file history"),
-            _ => {},
-        }
-    }
-    assert!(saw_history);
-
-    let _ = cmd_tx.send(GraphCommand::Shutdown);
-    cancel.store(true, std::sync::atomic::Ordering::SeqCst);
-    handle.join().unwrap();
+    harness.shutdown();
 }
 
 #[test]
 fn graph_service_uses_hidden_branch_names_as_deny_list() {
-    let (path, repo) = temp_repo("hidden-branches");
-    let root = commit(&repo, "root.txt", "root");
+    let (dir, repo) = temp_repo("hidden-branches");
+    let path = dir.join("repo");
+    let root = commit_file(&repo, "root.txt", "root", "root");
     let root_commit = repo.find_commit(root).unwrap();
     repo.branch("hidden", &root_commit, false).unwrap();
-    let visible = commit(&repo, "visible.txt", "visible");
+    let visible = commit_file(&repo, "visible.txt", "visible", "visible");
 
     repo.set_head("refs/heads/hidden").unwrap();
     repo.checkout_head(Some(CheckoutBuilder::default().force())).unwrap();
-    let hidden = commit(&repo, "hidden.txt", "hidden");
+    let hidden = commit_file(&repo, "hidden.txt", "hidden", "hidden");
 
-    let generation = 88;
-    let (cmd_tx, cmd_rx) = channel();
-    let (event_tx, event_rx) = channel();
-    let cancel = Arc::new(AtomicBool::new(false));
-    let handle = spawn_graph_service(
-        GraphServiceConfig {
-            generation,
-            path: path.display().to_string(),
-            amount: 10000,
-            hidden_branch_names: hidden_set(&["hidden"]),
-            include_head_reflog_roots: false,
-            graph_lane_limit: 20,
-            worktrees: Vec::new(),
-            symbols: SymbolTheme::main(),
-        },
-        cmd_rx,
-        event_tx,
-        cancel.clone(),
-    );
+    let harness = GraphServiceHarness::spawn(path, 88, 10000, hidden_set(&["hidden"]), false, Vec::new());
 
-    let mut complete = false;
-    for _ in 0..20 {
-        match event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
-            GraphEvent::Progress { generation: event_generation, is_complete, .. } if event_generation == generation && is_complete => {
-                complete = true;
-                break;
-            },
-            _ => {},
-        }
-    }
-    assert!(complete);
+    assert!(harness.wait_for_progress(true) > 0);
 
-    cmd_tx.send(GraphCommand::QueryGraphWindow { generation, request_id: 91, start: 0, end: 10 }).unwrap();
+    harness.send(GraphCommand::QueryGraphWindow { generation: 88, request_id: 91, start: 0, end: 10 });
+    let (rows, _, _) = harness.wait_for_window(91);
+    assert!(rows.iter().any(|row| row.oid == visible));
+    assert!(!rows.iter().any(|row| row.oid == hidden));
 
-    let mut saw_window = false;
-    for _ in 0..20 {
-        match event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
-            GraphEvent::GraphWindow { generation: event_generation, request_id: 91, rows, .. } if event_generation == generation => {
-                saw_window = true;
-                assert!(rows.iter().any(|row| row.oid == visible));
-                assert!(!rows.iter().any(|row| row.oid == hidden));
-                break;
-            },
-            _ => {},
-        }
-    }
-    assert!(saw_window);
+    harness.send(GraphCommand::QueryPaneWindow { generation: 88, pane: GraphPane::Branches, start: 0, end: 10 });
+    let rows = harness.wait_for_pane_window(GraphPane::Branches);
+    assert!(rows.iter().any(|row| matches!(row, GraphPaneRow::Branch { name, .. } if name == "hidden")));
 
-    cmd_tx.send(GraphCommand::QueryPaneWindow { generation, pane: GraphPane::Branches, start: 0, end: 10 }).unwrap();
-
-    let mut saw_pane = false;
-    for _ in 0..20 {
-        match event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
-            GraphEvent::PaneWindow { generation: event_generation, pane: GraphPane::Branches, rows, .. } if event_generation == generation => {
-                saw_pane = true;
-                assert!(rows.iter().any(|row| matches!(row, GraphPaneRow::Branch { name, .. } if name == "hidden")));
-                break;
-            },
-            _ => {},
-        }
-    }
-    assert!(saw_pane);
-
-    let _ = cmd_tx.send(GraphCommand::Shutdown);
-    cancel.store(true, std::sync::atomic::Ordering::SeqCst);
-    handle.join().unwrap();
+    harness.shutdown();
 }
 
 #[test]
 fn graph_service_omits_hidden_labels_on_visible_commits() {
-    let (path, repo) = temp_repo("hidden-labels");
-    let oid = commit(&repo, "one.txt", "one");
+    let (dir, repo) = temp_repo("hidden-labels");
+    let path = dir.join("repo");
+    let oid = commit_file(&repo, "one.txt", "one", "one");
+    let current_branch = repo.head().unwrap().shorthand().unwrap().to_string();
     let commit = repo.find_commit(oid).unwrap();
     repo.branch("hidden", &commit, false).unwrap();
     repo.reference("refs/remotes/origin/archive", oid, true, "test").unwrap();
 
-    let generation = 89;
-    let (cmd_tx, cmd_rx) = channel();
-    let (event_tx, event_rx) = channel();
-    let cancel = Arc::new(AtomicBool::new(false));
-    let handle = spawn_graph_service(
-        GraphServiceConfig {
-            generation,
-            path: path.display().to_string(),
-            amount: 10000,
-            hidden_branch_names: hidden_set(&["hidden", "origin/archive"]),
-            include_head_reflog_roots: false,
-            graph_lane_limit: 20,
-            worktrees: Vec::new(),
-            symbols: SymbolTheme::main(),
-        },
-        cmd_rx,
-        event_tx,
-        cancel.clone(),
-    );
+    let harness = GraphServiceHarness::spawn(path, 89, 10000, hidden_set(&["hidden", "origin/archive"]), false, Vec::new());
 
-    let mut complete = false;
-    for _ in 0..20 {
-        match event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
-            GraphEvent::Progress { generation: event_generation, is_complete, .. } if event_generation == generation && is_complete => {
-                complete = true;
-                break;
-            },
-            _ => {},
-        }
-    }
-    assert!(complete);
+    assert!(harness.wait_for_progress(true) > 0);
 
-    cmd_tx.send(GraphCommand::QueryGraphWindow { generation, request_id: 92, start: 0, end: 2 }).unwrap();
+    harness.send(GraphCommand::QueryGraphWindow { generation: 89, request_id: 92, start: 0, end: 2 });
+    let (rows, _, _) = harness.wait_for_window(92);
+    let row = rows.iter().find(|row| row.oid == oid).unwrap();
+    let labels: Vec<_> = row.branches.iter().map(|branch| branch.name.as_str()).collect();
+    assert!(!labels.contains(&"hidden"));
+    assert!(!labels.contains(&"origin/archive"));
+    assert!(labels.contains(&current_branch.as_str()));
 
-    let mut saw_window = false;
-    for _ in 0..20 {
-        match event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
-            GraphEvent::GraphWindow { generation: event_generation, request_id: 92, rows, .. } if event_generation == generation => {
-                saw_window = true;
-                let row = rows.iter().find(|row| row.oid == oid).unwrap();
-                let labels: Vec<_> = row.branches.iter().map(|branch| branch.name.as_str()).collect();
-                assert!(!labels.contains(&"hidden"));
-                assert!(!labels.contains(&"origin/archive"));
-                assert!(labels.contains(&"master"));
-                break;
-            },
-            _ => {},
-        }
-    }
-    assert!(saw_window);
-
-    let _ = cmd_tx.send(GraphCommand::Shutdown);
-    cancel.store(true, std::sync::atomic::Ordering::SeqCst);
-    handle.join().unwrap();
+    harness.shutdown();
 }
 
 fn hidden_set(names: &[&str]) -> HashSet<String> {

--- a/src/tests/core/graph_service.rs
+++ b/src/tests/core/graph_service.rs
@@ -1,242 +1,339 @@
 use super::*;
-use crate::git::test_support::{commit_file, temp_repo};
 use crate::helpers::symbols::SymbolTheme;
-use git2::build::CheckoutBuilder;
+use git2::{Oid, Repository, Signature, build::CheckoutBuilder};
 use im::HashSet;
 use std::{
-    path::PathBuf,
-    sync::{
-        Arc,
-        atomic::AtomicBool,
-        mpsc::{Receiver, Sender, channel},
-    },
-    time::Duration,
+    fs,
+    path::{Path, PathBuf},
+    sync::{Arc, atomic::AtomicBool, mpsc::channel},
+    time::{Duration, SystemTime, UNIX_EPOCH},
 };
 
-struct GraphServiceHarness {
-    generation: u64,
-    cmd_tx: Sender<GraphCommand>,
-    event_rx: Receiver<GraphEvent>,
-    cancel: Arc<AtomicBool>,
-    handle: std::thread::JoinHandle<()>,
+fn temp_repo(name: &str) -> (PathBuf, Repository) {
+    let id = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+    let path = std::env::temp_dir().join(format!("guitar-graph-service-{name}-{id}"));
+    fs::create_dir_all(&path).unwrap();
+    let repo = Repository::init(&path).unwrap();
+    {
+        let mut config = repo.config().unwrap();
+        config.set_str("user.name", "Test User").unwrap();
+        config.set_str("user.email", "test@example.com").unwrap();
+    }
+    (path, repo)
 }
 
-impl GraphServiceHarness {
-    fn spawn(path: PathBuf, generation: u64, amount: usize, hidden_branch_names: HashSet<String>, include_head_reflog_roots: bool, worktrees: Vec<WorktreeEntry>) -> Self {
-        let (cmd_tx, cmd_rx) = channel();
-        let (event_tx, event_rx) = channel();
-        let cancel = Arc::new(AtomicBool::new(false));
-        let handle = spawn_graph_service(
-            GraphServiceConfig { generation, path: path.display().to_string(), amount, hidden_branch_names, include_head_reflog_roots, graph_lane_limit: 20, worktrees, symbols: SymbolTheme::main() },
-            cmd_rx,
-            event_tx,
-            cancel.clone(),
-        );
+fn commit(repo: &Repository, file: &str, message: &str) -> Oid {
+    let workdir = repo.workdir().unwrap().to_path_buf();
+    fs::write(workdir.join(file), message).unwrap();
 
-        Self { generation, cmd_tx, event_rx, cancel, handle }
-    }
-
-    fn wait_for_progress(&self, is_complete: bool) -> usize {
-        for _ in 0..20 {
-            match self.event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
-                GraphEvent::Progress { generation, total, is_complete: event_complete, .. } if generation == self.generation && event_complete == is_complete => {
-                    return total;
-                },
-                _ => {},
-            }
-        }
-        panic!("timed out waiting for graph service progress");
-    }
-
-    fn wait_for_window(&self, request_id: u64) -> (Vec<GraphRow>, GraphHistory, usize) {
-        for _ in 0..20 {
-            match self.event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
-                GraphEvent::GraphWindow { generation, request_id: event_request_id, rows, history, total, .. } if generation == self.generation && event_request_id == request_id => {
-                    return (rows, history, total);
-                },
-                _ => {},
-            }
-        }
-        panic!("timed out waiting for graph window");
-    }
-
-    fn wait_for_lookup(&self, request_id: u64) -> GraphLookupResult {
-        for _ in 0..20 {
-            match self.event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
-                GraphEvent::LookupResult { generation, request_id: event_request_id, result, .. } if generation == self.generation && event_request_id == request_id => {
-                    return result;
-                },
-                _ => {},
-            }
-        }
-        panic!("timed out waiting for lookup result");
-    }
-
-    fn wait_for_worktrees(&self) -> (u64, Vec<WorktreeEntry>) {
-        for _ in 0..20 {
-            match self.event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
-                GraphEvent::Worktrees { generation, version, worktrees } if generation == self.generation => {
-                    return (version, worktrees);
-                },
-                _ => {},
-            }
-        }
-        panic!("timed out waiting for worktree update");
-    }
-
-    fn wait_for_pane_window(&self, pane: GraphPane) -> Vec<GraphPaneRow> {
-        for _ in 0..20 {
-            match self.event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
-                GraphEvent::PaneWindow { generation, pane: event_pane, rows, .. } if generation == self.generation && event_pane == pane => {
-                    return rows;
-                },
-                _ => {},
-            }
-        }
-        panic!("timed out waiting for pane window");
-    }
-
-    fn wait_for_file_history(&self, request_id: u64) -> (String, Vec<GraphFileHistoryRow>, Option<String>) {
-        for _ in 0..20 {
-            match self.event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
-                GraphEvent::FileHistory { generation, request_id: event_request_id, path, rows, error } if generation == self.generation && event_request_id == request_id => {
-                    return (path, rows, error);
-                },
-                _ => {},
-            }
-        }
-        panic!("timed out waiting for file history");
-    }
-
-    fn send(&self, command: GraphCommand) {
-        self.cmd_tx.send(command).unwrap();
-    }
-
-    fn shutdown(self) {
-        let _ = self.cmd_tx.send(GraphCommand::Shutdown);
-        self.cancel.store(true, std::sync::atomic::Ordering::SeqCst);
-        self.handle.join().unwrap();
-    }
+    let mut index = repo.index().unwrap();
+    index.add_path(Path::new(file)).unwrap();
+    index.write().unwrap();
+    let tree_oid = index.write_tree().unwrap();
+    let tree = repo.find_tree(tree_oid).unwrap();
+    let sig = Signature::now("Test User", "test@example.com").unwrap();
+    let parent = repo.head().ok().and_then(|head| head.peel_to_commit().ok());
+    let parents: Vec<&git2::Commit<'_>> = parent.iter().collect();
+    repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &parents).unwrap()
 }
 
 #[test]
 fn graph_service_reports_progress_and_answers_visible_window() {
-    let (dir, repo) = temp_repo("window");
-    let path = dir.join("repo");
-    commit_file(&repo, "one.txt", "one", "one");
-    let two = commit_file(&repo, "two.txt", "two", "two");
-    let harness = GraphServiceHarness::spawn(path.clone(), 42, 1, HashSet::new(), false, Vec::new());
+    let (path, repo) = temp_repo("window");
+    commit(&repo, "one.txt", "one");
+    let two = commit(&repo, "two.txt", "two");
 
-    assert!(harness.wait_for_progress(false) > 0);
+    let generation = 42;
+    let (cmd_tx, cmd_rx) = channel();
+    let (event_tx, event_rx) = channel();
+    let cancel = Arc::new(AtomicBool::new(false));
+    let handle = spawn_graph_service(
+        GraphServiceConfig {
+            generation,
+            path: path.display().to_string(),
+            amount: 1,
+            hidden_branch_names: HashSet::new(),
+            include_head_reflog_roots: false,
+            graph_lane_limit: 20,
+            worktrees: Vec::new(),
+            symbols: SymbolTheme::main(),
+        },
+        cmd_rx,
+        event_tx,
+        cancel.clone(),
+    );
 
-    harness.send(GraphCommand::QueryGraphWindow { generation: 42, request_id: 7, start: 0, end: 2 });
-    let (rows, history, total) = harness.wait_for_window(7);
-    assert!(total >= rows.len());
-    assert!(!rows.is_empty());
-    assert!(!history.is_empty());
-    assert!(rows.len() <= 2);
+    let mut saw_progress = false;
+    for _ in 0..20 {
+        match event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
+            GraphEvent::Progress { generation: event_generation, total, .. } if event_generation == generation => {
+                saw_progress = true;
+                assert!(total > 0);
+                break;
+            },
+            _ => {},
+        }
+    }
+    assert!(saw_progress);
 
-    harness.send(GraphCommand::Lookup { generation: 42, request_id: 8, kind: GraphLookupKind::ShaPrefix { prefix: two.to_string()[..8].to_string() } });
-    assert!(matches!(harness.wait_for_lookup(8), GraphLookupResult::Index(Some(_))));
+    cmd_tx.send(GraphCommand::QueryGraphWindow { generation, request_id: 7, start: 0, end: 2 }).unwrap();
 
-    harness.send(GraphCommand::Lookup { generation: 42, request_id: 9, kind: GraphLookupKind::Oid { oid: two } });
-    assert!(matches!(harness.wait_for_lookup(9), GraphLookupResult::Index(Some(1))));
+    let mut saw_window = false;
+    for _ in 0..20 {
+        match event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
+            GraphEvent::GraphWindow { generation: event_generation, request_id, rows, history, total, .. } if event_generation == generation && request_id == 7 => {
+                saw_window = true;
+                assert!(total >= rows.len());
+                assert!(!rows.is_empty());
+                assert!(!history.is_empty());
+                assert!(rows.len() <= 2);
+                break;
+            },
+            _ => {},
+        }
+    }
+    assert!(saw_window);
 
-    let updated = vec![WorktreeEntry {
-        name: "repo".to_string(),
-        path,
-        branch: Some("master".to_string()),
-        head: Some(two),
-        alias: None,
-        kind: crate::core::worktrees::WorktreeKind::Main,
-        is_current: true,
-        is_valid: true,
-        is_prunable: false,
-        locked_reason: None,
-        is_dirty: true,
-    }];
-    harness.send(GraphCommand::UpdateWorktrees { generation: 42, worktrees: updated.clone() });
-    let (_, worktrees) = harness.wait_for_worktrees();
-    assert_eq!(worktrees, updated);
+    cmd_tx.send(GraphCommand::Lookup { generation, request_id: 8, kind: GraphLookupKind::ShaPrefix { prefix: two.to_string()[..8].to_string() } }).unwrap();
 
-    harness.shutdown();
+    let mut saw_lookup = false;
+    for _ in 0..20 {
+        match event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
+            GraphEvent::LookupResult { generation: event_generation, request_id, result: GraphLookupResult::Index(Some(_)), .. } if event_generation == generation && request_id == 8 => {
+                saw_lookup = true;
+                break;
+            },
+            _ => {},
+        }
+    }
+    assert!(saw_lookup);
+
+    cmd_tx.send(GraphCommand::Lookup { generation, request_id: 9, kind: GraphLookupKind::Oid { oid: two } }).unwrap();
+
+    let mut saw_oid_lookup = false;
+    for _ in 0..20 {
+        match event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
+            GraphEvent::LookupResult { generation: event_generation, request_id, result: GraphLookupResult::Index(Some(index)), .. } if event_generation == generation && request_id == 9 => {
+                saw_oid_lookup = true;
+                assert_eq!(index, 1);
+                break;
+            },
+            _ => {},
+        }
+    }
+    assert!(saw_oid_lookup);
+
+    let _ = cmd_tx.send(GraphCommand::Shutdown);
+    cancel.store(true, std::sync::atomic::Ordering::SeqCst);
+    handle.join().unwrap();
 }
 
 #[test]
 fn graph_service_file_history_returns_visible_graph_indices() {
-    let (dir, repo) = temp_repo("file-history");
-    let path = dir.join("repo");
-    let first = commit_file(&repo, "target.txt", "first", "first");
-    commit_file(&repo, "other.txt", "other", "other");
-    let latest = commit_file(&repo, "target.txt", "latest", "latest");
-    let harness = GraphServiceHarness::spawn(path, 77, 10000, HashSet::new(), false, Vec::new());
+    let (path, repo) = temp_repo("file-history");
+    let first = commit(&repo, "target.txt", "first");
+    commit(&repo, "other.txt", "other");
+    let latest = commit(&repo, "target.txt", "latest");
 
-    assert!(harness.wait_for_progress(true) > 0);
+    let generation = 77;
+    let (cmd_tx, cmd_rx) = channel();
+    let (event_tx, event_rx) = channel();
+    let cancel = Arc::new(AtomicBool::new(false));
+    let handle = spawn_graph_service(
+        GraphServiceConfig {
+            generation,
+            path: path.display().to_string(),
+            amount: 10000,
+            hidden_branch_names: HashSet::new(),
+            include_head_reflog_roots: false,
+            graph_lane_limit: 20,
+            worktrees: Vec::new(),
+            symbols: SymbolTheme::main(),
+        },
+        cmd_rx,
+        event_tx,
+        cancel.clone(),
+    );
 
-    harness.send(GraphCommand::QueryFileHistory { generation: 78, request_id: 41, path: "target.txt".to_string() });
-    harness.send(GraphCommand::QueryFileHistory { generation: 77, request_id: 42, path: "target.txt".to_string() });
+    let mut complete = false;
+    for _ in 0..20 {
+        match event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
+            GraphEvent::Progress { generation: event_generation, is_complete, .. } if event_generation == generation && is_complete => {
+                complete = true;
+                break;
+            },
+            _ => {},
+        }
+    }
+    assert!(complete);
 
-    let (path, rows, error) = harness.wait_for_file_history(42);
-    assert_eq!(path, "target.txt");
-    assert_eq!(error, None);
-    assert_eq!(rows.iter().map(|row| row.graph_index).collect::<Vec<_>>(), vec![1, 3]);
-    assert_eq!(rows.iter().map(|row| row.oid).collect::<Vec<_>>(), vec![latest, first]);
+    cmd_tx.send(GraphCommand::QueryFileHistory { generation: generation + 1, request_id: 41, path: "target.txt".to_string() }).unwrap();
+    cmd_tx.send(GraphCommand::QueryFileHistory { generation, request_id: 42, path: "target.txt".to_string() }).unwrap();
 
-    harness.shutdown();
+    let mut saw_history = false;
+    for _ in 0..20 {
+        match event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
+            GraphEvent::FileHistory { generation: event_generation, request_id, path, rows, error } if event_generation == generation && request_id == 42 => {
+                saw_history = true;
+                assert_eq!(path, "target.txt");
+                assert_eq!(error, None);
+                assert_eq!(rows.iter().map(|row| row.graph_index).collect::<Vec<_>>(), vec![1, 3]);
+                assert_eq!(rows.iter().map(|row| row.oid).collect::<Vec<_>>(), vec![latest, first]);
+                break;
+            },
+            GraphEvent::FileHistory { request_id: 41, .. } => panic!("stale generation should not produce file history"),
+            _ => {},
+        }
+    }
+    assert!(saw_history);
+
+    let _ = cmd_tx.send(GraphCommand::Shutdown);
+    cancel.store(true, std::sync::atomic::Ordering::SeqCst);
+    handle.join().unwrap();
 }
 
 #[test]
 fn graph_service_uses_hidden_branch_names_as_deny_list() {
-    let (dir, repo) = temp_repo("hidden-branches");
-    let path = dir.join("repo");
-    let root = commit_file(&repo, "root.txt", "root", "root");
+    let (path, repo) = temp_repo("hidden-branches");
+    let root = commit(&repo, "root.txt", "root");
     let root_commit = repo.find_commit(root).unwrap();
     repo.branch("hidden", &root_commit, false).unwrap();
-    let visible = commit_file(&repo, "visible.txt", "visible", "visible");
+    let visible = commit(&repo, "visible.txt", "visible");
 
     repo.set_head("refs/heads/hidden").unwrap();
     repo.checkout_head(Some(CheckoutBuilder::default().force())).unwrap();
-    let hidden = commit_file(&repo, "hidden.txt", "hidden", "hidden");
+    let hidden = commit(&repo, "hidden.txt", "hidden");
 
-    let harness = GraphServiceHarness::spawn(path, 88, 10000, hidden_set(&["hidden"]), false, Vec::new());
+    let generation = 88;
+    let (cmd_tx, cmd_rx) = channel();
+    let (event_tx, event_rx) = channel();
+    let cancel = Arc::new(AtomicBool::new(false));
+    let handle = spawn_graph_service(
+        GraphServiceConfig {
+            generation,
+            path: path.display().to_string(),
+            amount: 10000,
+            hidden_branch_names: hidden_set(&["hidden"]),
+            include_head_reflog_roots: false,
+            graph_lane_limit: 20,
+            worktrees: Vec::new(),
+            symbols: SymbolTheme::main(),
+        },
+        cmd_rx,
+        event_tx,
+        cancel.clone(),
+    );
 
-    assert!(harness.wait_for_progress(true) > 0);
+    let mut complete = false;
+    for _ in 0..20 {
+        match event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
+            GraphEvent::Progress { generation: event_generation, is_complete, .. } if event_generation == generation && is_complete => {
+                complete = true;
+                break;
+            },
+            _ => {},
+        }
+    }
+    assert!(complete);
 
-    harness.send(GraphCommand::QueryGraphWindow { generation: 88, request_id: 91, start: 0, end: 10 });
-    let (rows, _, _) = harness.wait_for_window(91);
-    assert!(rows.iter().any(|row| row.oid == visible));
-    assert!(!rows.iter().any(|row| row.oid == hidden));
+    cmd_tx.send(GraphCommand::QueryGraphWindow { generation, request_id: 91, start: 0, end: 10 }).unwrap();
 
-    harness.send(GraphCommand::QueryPaneWindow { generation: 88, pane: GraphPane::Branches, start: 0, end: 10 });
-    let rows = harness.wait_for_pane_window(GraphPane::Branches);
-    assert!(rows.iter().any(|row| matches!(row, GraphPaneRow::Branch { name, .. } if name == "hidden")));
+    let mut saw_window = false;
+    for _ in 0..20 {
+        match event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
+            GraphEvent::GraphWindow { generation: event_generation, request_id: 91, rows, .. } if event_generation == generation => {
+                saw_window = true;
+                assert!(rows.iter().any(|row| row.oid == visible));
+                assert!(!rows.iter().any(|row| row.oid == hidden));
+                break;
+            },
+            _ => {},
+        }
+    }
+    assert!(saw_window);
 
-    harness.shutdown();
+    cmd_tx.send(GraphCommand::QueryPaneWindow { generation, pane: GraphPane::Branches, start: 0, end: 10 }).unwrap();
+
+    let mut saw_pane = false;
+    for _ in 0..20 {
+        match event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
+            GraphEvent::PaneWindow { generation: event_generation, pane: GraphPane::Branches, rows, .. } if event_generation == generation => {
+                saw_pane = true;
+                assert!(rows.iter().any(|row| matches!(row, GraphPaneRow::Branch { name, .. } if name == "hidden")));
+                break;
+            },
+            _ => {},
+        }
+    }
+    assert!(saw_pane);
+
+    let _ = cmd_tx.send(GraphCommand::Shutdown);
+    cancel.store(true, std::sync::atomic::Ordering::SeqCst);
+    handle.join().unwrap();
 }
 
 #[test]
 fn graph_service_omits_hidden_labels_on_visible_commits() {
-    let (dir, repo) = temp_repo("hidden-labels");
-    let path = dir.join("repo");
-    let oid = commit_file(&repo, "one.txt", "one", "one");
-    let current_branch = repo.head().unwrap().shorthand().unwrap().to_string();
+    let (path, repo) = temp_repo("hidden-labels");
+    let oid = commit(&repo, "one.txt", "one");
     let commit = repo.find_commit(oid).unwrap();
     repo.branch("hidden", &commit, false).unwrap();
     repo.reference("refs/remotes/origin/archive", oid, true, "test").unwrap();
 
-    let harness = GraphServiceHarness::spawn(path, 89, 10000, hidden_set(&["hidden", "origin/archive"]), false, Vec::new());
+    let generation = 89;
+    let (cmd_tx, cmd_rx) = channel();
+    let (event_tx, event_rx) = channel();
+    let cancel = Arc::new(AtomicBool::new(false));
+    let handle = spawn_graph_service(
+        GraphServiceConfig {
+            generation,
+            path: path.display().to_string(),
+            amount: 10000,
+            hidden_branch_names: hidden_set(&["hidden", "origin/archive"]),
+            include_head_reflog_roots: false,
+            graph_lane_limit: 20,
+            worktrees: Vec::new(),
+            symbols: SymbolTheme::main(),
+        },
+        cmd_rx,
+        event_tx,
+        cancel.clone(),
+    );
 
-    assert!(harness.wait_for_progress(true) > 0);
+    let mut complete = false;
+    for _ in 0..20 {
+        match event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
+            GraphEvent::Progress { generation: event_generation, is_complete, .. } if event_generation == generation && is_complete => {
+                complete = true;
+                break;
+            },
+            _ => {},
+        }
+    }
+    assert!(complete);
 
-    harness.send(GraphCommand::QueryGraphWindow { generation: 89, request_id: 92, start: 0, end: 2 });
-    let (rows, _, _) = harness.wait_for_window(92);
-    let row = rows.iter().find(|row| row.oid == oid).unwrap();
-    let labels: Vec<_> = row.branches.iter().map(|branch| branch.name.as_str()).collect();
-    assert!(!labels.contains(&"hidden"));
-    assert!(!labels.contains(&"origin/archive"));
-    assert!(labels.contains(&current_branch.as_str()));
+    cmd_tx.send(GraphCommand::QueryGraphWindow { generation, request_id: 92, start: 0, end: 2 }).unwrap();
 
-    harness.shutdown();
+    let mut saw_window = false;
+    for _ in 0..20 {
+        match event_rx.recv_timeout(Duration::from_millis(250)).unwrap() {
+            GraphEvent::GraphWindow { generation: event_generation, request_id: 92, rows, .. } if event_generation == generation => {
+                saw_window = true;
+                let row = rows.iter().find(|row| row.oid == oid).unwrap();
+                let labels: Vec<_> = row.branches.iter().map(|branch| branch.name.as_str()).collect();
+                assert!(!labels.contains(&"hidden"));
+                assert!(!labels.contains(&"origin/archive"));
+                assert!(labels.contains(&"master"));
+                break;
+            },
+            _ => {},
+        }
+    }
+    assert!(saw_window);
+
+    let _ = cmd_tx.send(GraphCommand::Shutdown);
+    cancel.store(true, std::sync::atomic::Ordering::SeqCst);
+    handle.join().unwrap();
 }
 
 fn hidden_set(names: &[&str]) -> HashSet<String> {

--- a/src/tests/core/oids.rs
+++ b/src/tests/core/oids.rs
@@ -1,0 +1,52 @@
+use super::*;
+
+fn oid_with_prefix(prefix: u64, suffix: u64) -> Oid {
+    let mut bytes = [0u8; 20];
+    bytes[..8].copy_from_slice(&prefix.to_be_bytes());
+    bytes[8..16].copy_from_slice(&suffix.to_be_bytes());
+    bytes[16..20].copy_from_slice(&(suffix as u32).wrapping_mul(2_654_435_761).to_be_bytes());
+    Oid::from_bytes(&bytes).unwrap()
+}
+
+fn assert_round_trip(oids: &mut Oids, oid: Oid, alias: u32) {
+    assert_eq!(oids.get_alias_by_oid(oid), alias);
+    assert_eq!(oids.get_existing_alias(oid), Some(alias));
+    assert_eq!(oids.get_git2_oid_by_alias(alias), oid);
+}
+
+#[test]
+fn aliases_lookup_across_many_similar_inserted_oids() {
+    let mut oids = Oids::default();
+    let first = oid_with_prefix(0xfeed_beef_0000_0001, 10);
+    let boundary = oid_with_prefix(0xfeed_beef_ffff_ffff, 20);
+    let first_alias = oids.get_alias_by_oid(first);
+
+    for suffix in 1..2048 {
+        oids.get_alias_by_oid(oid_with_prefix(0xfeed_beef_0000_0000 | suffix, suffix + 10_000));
+    }
+
+    let boundary_alias = oids.get_alias_by_oid(boundary);
+    assert_eq!(first_alias, 0);
+    assert_eq!(boundary_alias, 2048);
+    assert_round_trip(&mut oids, first, first_alias);
+    assert_round_trip(&mut oids, boundary, boundary_alias);
+}
+
+#[test]
+fn prefix_lookup_returns_existing_alias_without_reinterning_oid() {
+    let mut oids = Oids::default();
+    let first = oid_with_prefix(0x1234_5678_0000_0001, 10);
+    let second = oid_with_prefix(0xabcd_5678_0000_0001, 20);
+    let missing = oid_with_prefix(0xffff_5678_0000_0001, 30);
+
+    let first_alias = oids.get_alias_by_oid(first);
+    let second_alias = oids.get_alias_by_oid(second);
+
+    assert_eq!(oids.get_alias_by_prefix("12345678"), Some(first_alias));
+    assert_eq!(oids.get_alias_by_prefix("abcd5678"), Some(second_alias));
+    assert_eq!(oids.get_alias_by_prefix("ABCD5678"), Some(second_alias));
+    assert_eq!(oids.get_alias_by_prefix("ffff"), None);
+    assert_eq!(oids.get_alias_by_prefix("abcdx"), None);
+    assert_eq!(oids.get_existing_alias(missing), None);
+    assert_eq!(oids.len(), 2);
+}

--- a/src/tests/core/oids.rs
+++ b/src/tests/core/oids.rs
@@ -11,7 +11,7 @@ fn oid_with_prefix(prefix: u64, suffix: u64) -> Oid {
 fn assert_round_trip(oids: &mut Oids, oid: Oid, alias: u32) {
     assert_eq!(oids.get_alias_by_oid(oid), alias);
     assert_eq!(oids.get_existing_alias(oid), Some(alias));
-    assert_eq!(oids.get_git2_oid_by_alias(alias), oid);
+    assert_eq!(oids.get_oid_by_alias(alias), oid);
 }
 
 #[test]

--- a/src/tests/core/walker.rs
+++ b/src/tests/core/walker.rs
@@ -1,74 +1,31 @@
 use super::*;
 use crate::{
-    core::{graph_service::GraphRow, renderers::render_graph_projection},
+    core::{
+        graph_service::GraphRow,
+        oids::{Oids, gix_to_git2_oid},
+        renderers::render_graph_projection,
+    },
+    git::actions::worktrees::create_worktree,
+    git::queries::commits::get_tag_oids,
+    git::test_support::{TestDir, commit_file, commit_file_with_parents, stash_tracked_change, temp_repo},
     helpers::{
         palette::Theme,
         symbols::{SymbolTheme, graph},
     },
 };
-use git2::{Oid, ResetType, Signature, Time};
+use git2::{Oid, Repository, ResetType, Signature};
 use ratatui::text::Line;
 use std::{
-    fs,
+    collections::HashSet as StdHashSet,
     path::{Path, PathBuf},
-    time::{SystemTime, UNIX_EPOCH},
 };
-
-fn temp_repo(name: &str) -> (PathBuf, Repository) {
-    let id = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
-    let path = std::env::temp_dir().join(format!("guitar-walker-reflog-{name}-{id}"));
-    fs::create_dir_all(&path).unwrap();
-    let repo = Repository::init(&path).unwrap();
-    {
-        let mut config = repo.config().unwrap();
-        config.set_str("user.name", "Test User").unwrap();
-        config.set_str("user.email", "test@example.com").unwrap();
-    }
-    (path, repo)
-}
-
-fn commit(repo: &Repository, file: &str, message: &str) -> Oid {
-    let workdir = repo.workdir().unwrap().to_path_buf();
-    fs::write(workdir.join(file), message).unwrap();
-
-    let mut index = repo.index().unwrap();
-    index.add_path(Path::new(file)).unwrap();
-    index.write().unwrap();
-    let tree_oid = index.write_tree().unwrap();
-    let tree = repo.find_tree(tree_oid).unwrap();
-    let sig = Signature::now("Test User", "test@example.com").unwrap();
-    let parent = repo.head().ok().and_then(|head| head.peel_to_commit().ok());
-    let parents: Vec<&git2::Commit<'_>> = parent.iter().collect();
-    repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &parents).unwrap()
-}
-
-fn stash_tracked_change(repo: &mut Repository, file: &str, message: &str) -> Oid {
-    let workdir = repo.workdir().unwrap().to_path_buf();
-    fs::write(workdir.join(file), message).unwrap();
-    let sig = repo.signature().unwrap();
-    repo.stash_save(&sig, message, None).unwrap()
-}
-
-fn commit_with_parents(repo: &Repository, file: &str, message: &str, parents: &[Oid], time: i64) -> Oid {
-    let workdir = repo.workdir().unwrap().to_path_buf();
-    fs::write(workdir.join(file), message).unwrap();
-
-    let mut index = repo.index().unwrap();
-    index.add_path(Path::new(file)).unwrap();
-    index.write().unwrap();
-    let tree_oid = index.write_tree().unwrap();
-    let tree = repo.find_tree(tree_oid).unwrap();
-    let sig = Signature::new("Test User", "test@example.com", &Time::new(time, 0)).unwrap();
-    let parent_commits: Vec<_> = parents.iter().map(|oid| repo.find_commit(*oid).unwrap()).collect();
-    let parent_refs: Vec<&git2::Commit<'_>> = parent_commits.iter().collect();
-    repo.commit(None, &sig, &sig, message, &tree, &parent_refs).unwrap()
-}
 
 fn graph_row(index: usize, alias: u32, oid: Oid) -> GraphRow {
     GraphRow {
         index,
         alias,
         oid,
+        short_oid: oid.to_string()[..9].to_string(),
         summary: String::new(),
         committer_date: String::new(),
         committer_name: String::new(),
@@ -79,6 +36,7 @@ fn graph_row(index: usize, alias: u32, oid: Oid) -> GraphRow {
         is_stash: false,
         stash_lane: None,
         worktrees: Vec::new(),
+        has_current_worktree: false,
         reflog: None,
     }
 }
@@ -87,79 +45,118 @@ fn line_text(line: &Line<'_>) -> String {
     line.spans.iter().map(|span| span.content.as_ref()).collect()
 }
 
+fn walked_walker(path: &Path, buffer_size: usize, include_head_reflog_roots: bool) -> Walker {
+    let mut walker = Walker::new(path.display().to_string(), buffer_size, HashSet::new(), include_head_reflog_roots, 20).unwrap();
+    while walker.walk() {}
+    walker
+}
+
+fn representative_graph_fixture(name: &str, tail_commits: usize) -> (TestDir, PathBuf, Repository) {
+    let (dir, repo) = temp_repo(name);
+    let path = dir.join("repo");
+    let root = commit_file(&repo, "root.txt", "root", "root");
+    let main_1 = commit_file_with_parents(&repo, "main.txt", "main-1", "main-1", &[root], Some(1));
+    let side_1 = commit_file_with_parents(&repo, "side.txt", "side-1", "side-1", &[root], Some(2));
+    let main_2 = commit_file_with_parents(&repo, "main.txt", "main-2", "main-2", &[main_1], Some(3));
+    let side_2 = commit_file_with_parents(&repo, "side.txt", "side-2", "side-2", &[side_1], Some(4));
+    let merge = commit_file_with_parents(&repo, "merge.txt", "merge", "merge", &[main_2, side_2], Some(5));
+
+    let mut tip = commit_file_with_parents(&repo, "tail.txt", "tail-0", "tail-0", &[merge], Some(6));
+    for idx in 1..tail_commits {
+        let value = format!("tail-{idx}");
+        tip = commit_file_with_parents(&repo, "tail.txt", &value, &value, &[tip], Some(6 + idx as i64));
+    }
+
+    repo.reference("refs/heads/main", tip, true, "test").unwrap();
+    repo.reference("refs/heads/feature", side_2, true, "test").unwrap();
+    repo.reference("refs/tags/v-main", main_1, true, "test").unwrap();
+    repo.set_head("refs/heads/main").unwrap();
+
+    (dir, path, repo)
+}
+
+fn linked_worktree_startup_fixture(name: &str) -> (TestDir, PathBuf, PathBuf, Repository) {
+    let (dir, path, repo) = representative_graph_fixture(name, 32);
+    let head = repo.head().unwrap().target().unwrap();
+    let linked_path = path.parent().unwrap_or_else(|| Path::new(".")).join(format!("{}-linked", path.file_name().and_then(|name| name.to_str()).unwrap_or("repo")));
+    create_worktree(&repo, "linked", &linked_path, head).unwrap();
+    (dir, path, linked_path, repo)
+}
+
 #[test]
 fn walker_loads_commit_reachable_only_from_head_reflog() {
-    let (path, repo) = temp_repo("lost-root");
-    let base = commit(&repo, "file.txt", "base");
-    let lost = commit(&repo, "file.txt", "lost");
+    let (dir, repo) = temp_repo("lost-root");
+    let path = dir.join("repo");
+    let base = commit_file(&repo, "file.txt", "base", "base");
+    let lost = commit_file(&repo, "file.txt", "lost", "lost");
     let base_commit = repo.find_commit(base).unwrap();
     repo.reset(base_commit.as_object(), ResetType::Hard, None).unwrap();
 
-    let mut walker = Walker::new(path.display().to_string(), 100, HashSet::new(), true, 20).unwrap();
-    walker.walk();
-    let lost_alias = walker.oids.aliases.get(&lost).copied().unwrap();
+    let walker = walked_walker(&path, 100, true);
+    let lost_alias = walker.oids.get_existing_alias(lost).unwrap();
 
     assert!(walker.oids.get_sorted_aliases().contains(&lost_alias));
 }
 
 #[test]
 fn walker_can_hide_commit_reachable_only_from_head_reflog() {
-    let (path, repo) = temp_repo("hidden-lost-root");
-    let base = commit(&repo, "file.txt", "base");
-    let lost = commit(&repo, "file.txt", "lost");
+    let (dir, repo) = temp_repo("hidden-lost-root");
+    let path = dir.join("repo");
+    let base = commit_file(&repo, "file.txt", "base", "base");
+    let lost = commit_file(&repo, "file.txt", "lost", "lost");
     let base_commit = repo.find_commit(base).unwrap();
     repo.reset(base_commit.as_object(), ResetType::Hard, None).unwrap();
 
-    let mut walker = Walker::new(path.display().to_string(), 100, HashSet::new(), false, 20).unwrap();
-    walker.walk();
-    let lost_alias = walker.oids.aliases.get(&lost).copied().unwrap();
+    let walker = walked_walker(&path, 100, false);
+    let lost_alias = walker.oids.get_existing_alias(lost).unwrap();
 
     assert!(!walker.oids.get_sorted_aliases().contains(&lost_alias));
-    assert!(walker.head_reflog_entries.iter().any(|entry| entry.new_oid == lost));
+    assert!(walker.head_reflog_entries.iter().any(|entry| gix_to_git2_oid(entry.new_oid) == lost));
 }
 
 #[test]
 fn walker_expires_new_right_merge_lane_before_next_rendered_row() {
-    let (path, repo) = temp_repo("transient-merge-lane");
-    let root = commit_with_parents(&repo, "root.txt", "root", &[], 1);
-    let left_parent = commit_with_parents(&repo, "left-parent.txt", "left parent", &[root], 2);
-    let right_parent = commit_with_parents(&repo, "right-parent.txt", "right parent", &[root], 3);
-    let merge = commit_with_parents(&repo, "merge.txt", "merge", &[left_parent, right_parent], 4);
-    let right_tip = commit_with_parents(&repo, "right-tip.txt", "right tip", &[right_parent], 5);
-    let left_tip = commit_with_parents(&repo, "left-tip.txt", "left tip", &[left_parent], 6);
+    let (dir, repo) = temp_repo("transient-merge-lane");
+    let path = dir.join("repo");
+    let root = commit_file_with_parents(&repo, "root.txt", "root", "root", &[], Some(1));
+    let left_parent = commit_file_with_parents(&repo, "left-parent.txt", "left parent", "left parent", &[root], Some(2));
+    let right_parent = commit_file_with_parents(&repo, "right-parent.txt", "right parent", "right parent", &[root], Some(3));
+    let merge = commit_file_with_parents(&repo, "merge.txt", "merge", "merge", &[left_parent, right_parent], Some(4));
+    let right_tip = commit_file_with_parents(&repo, "right-tip.txt", "right tip", "right tip", &[right_parent], Some(5));
+    let left_tip = commit_file_with_parents(&repo, "left-tip.txt", "left tip", "left tip", &[left_parent], Some(6));
 
     repo.reference("refs/heads/main", left_tip, true, "test").unwrap();
     repo.reference("refs/heads/right", right_tip, true, "test").unwrap();
     repo.reference("refs/heads/merge", merge, true, "test").unwrap();
     repo.set_head("refs/heads/main").unwrap();
 
-    let mut walker = Walker::new(path.display().to_string(), 100, HashSet::new(), false, 20).unwrap();
-    while walker.walk() {}
+    let walker = walked_walker(&path, 100, false);
 
-    let merge_alias = walker.oids.aliases.get(&merge).copied().unwrap();
-    let head_alias = walker.oids.aliases.get(&left_tip).copied().unwrap();
+    let merge_alias = walker.oids.get_existing_alias(merge).unwrap();
+    let head_alias = walker.oids.get_existing_alias(left_tip).unwrap();
     let aliases = walker.oids.get_sorted_aliases().clone();
     let merge_idx = aliases.iter().position(|alias| *alias == merge_alias).unwrap();
     assert!(merge_idx + 1 < aliases.len());
 
     let history = walker.buffer.borrow().window(0, aliases.len().saturating_add(1));
     let merge_history_idx = merge_idx;
-    let merge_lane = history[merge_history_idx].iter().position(|chunk| chunk.alias == merge_alias).unwrap();
+    let merge_lane = history.get(merge_history_idx).unwrap().iter().position(|chunk| chunk.alias == merge_alias).unwrap();
 
-    assert_eq!(merge_lane + 1, history[merge_history_idx].len());
-    assert!(history[merge_history_idx + 1].get(merge_lane).is_none());
+    assert_eq!(merge_lane + 1, history.get(merge_history_idx).unwrap().len());
+    assert!(history.get(merge_history_idx + 1).unwrap().get(merge_lane).is_none());
 
     let rows: Vec<_> = aliases
         .iter()
         .enumerate()
         .map(|(index, &alias)| {
-            let mut row = graph_row(index, alias, *walker.oids.get_oid_by_alias(alias));
+            let mut row = graph_row(index, alias, walker.oids.get_oid_by_alias(alias));
             row.is_merge = alias == merge_alias;
             row
         })
         .collect();
     let symbols = SymbolTheme::main();
-    let lines = render_graph_projection(&Theme::classic(), &symbols, &rows, &history, head_alias, 0, aliases.len(), true);
+    let theme = Theme::classic();
+    let lines = render_graph_projection(&theme, &symbols, &rows, &history, head_alias, 0, aliases.len(), true);
     let merge_text = line_text(&lines[merge_idx]);
     let next_text = line_text(&lines[merge_idx + 1]);
     let merge_col = merge_text.chars().position(|ch| ch == graph::MERGE.chars().next().unwrap()).unwrap();
@@ -169,19 +166,19 @@ fn walker_expires_new_right_merge_lane_before_next_rendered_row() {
 
 #[test]
 fn walker_records_ref_stash_and_reflog_lanes_from_update_lane() {
-    let (path, mut repo) = temp_repo("cached-lanes");
-    let base = commit(&repo, "file.txt", "base");
+    let (dir, mut repo) = temp_repo("cached-lanes");
+    let path = dir.join("repo");
+    let base = commit_file(&repo, "file.txt", "base", "base");
     {
         let base_commit = repo.find_commit(base).unwrap();
         repo.tag_lightweight("v-base", base_commit.as_object(), false).unwrap();
     }
-    let stash = stash_tracked_change(&mut repo, "file.txt", "stashed change");
+    let stash = stash_tracked_change(&mut repo, "file.txt", "stashed change", "stashed change");
 
-    let mut walker = Walker::new(path.display().to_string(), 100, HashSet::new(), true, 20).unwrap();
-    while walker.walk() {}
+    let walker = walked_walker(&path, 100, true);
 
-    let base_alias = walker.oids.aliases.get(&base).copied().unwrap();
-    let stash_alias = walker.oids.aliases.get(&stash).copied().unwrap();
+    let base_alias = walker.oids.get_existing_alias(base).unwrap();
+    let stash_alias = walker.oids.get_existing_alias(stash).unwrap();
 
     assert!(walker.branches_lanes.contains_key(&base_alias));
     assert!(walker.tags_lanes.contains_key(&base_alias));
@@ -190,17 +187,102 @@ fn walker_records_ref_stash_and_reflog_lanes_from_update_lane() {
 }
 
 #[test]
-fn walker_keeps_stash_adjacent_to_its_base_parent() {
-    let (path, mut repo) = temp_repo("stash-order");
-    let base = commit(&repo, "file.txt", "base");
-    let stash = stash_tracked_change(&mut repo, "file.txt", "stashed change");
+fn walker_new_collects_startup_metadata_before_walking() {
+    let (_dir, path, mut repo) = representative_graph_fixture("startup-metadata", 32);
+    let stash = stash_tracked_change(&mut repo, "tail.txt", "stashed change", "stashed change");
 
-    let mut walker = Walker::new(path.display().to_string(), 100, HashSet::new(), false, 20).unwrap();
-    while walker.walk() {}
+    let walker = Walker::new(path.display().to_string(), 100, HashSet::new(), true, 20).unwrap();
+
+    assert!(walker.branches_local.values().flatten().any(|name| name == "main"));
+    assert!(walker.branches_local.values().flatten().any(|name| name == "feature"));
+    assert!(walker.tags_local.values().flatten().any(|name| name == "v-main"));
+    assert!(!walker.oids.stashes.is_empty());
+    assert!(walker.oids.get_existing_alias(stash).is_some());
+    assert!(!walker.head_reflog_entries.is_empty());
+}
+
+#[test]
+fn walker_matches_rev_list_all_for_lightweight_and_annotated_tags() {
+    for annotated in [false, true] {
+        let (dir, repo) = temp_repo(if annotated { "annotated-tag-root" } else { "tag-only-root" });
+        let path = dir.join("repo");
+        let root = commit_file(&repo, "root.txt", "root", "root");
+        let branch_tip = commit_file(&repo, "branch.txt", "branch", "branch");
+        let tagged = commit_file_with_parents(&repo, "tagged.txt", "tagged", "tagged", &[], Some(if annotated { 100 } else { 99 }));
+        let tagged_commit = repo.find_commit(tagged).unwrap();
+
+        if annotated {
+            let sig = Signature::now("Test User", "test@example.com").unwrap();
+            repo.tag("annotated", tagged_commit.as_object(), &sig, "annotated", false).unwrap();
+        } else {
+            repo.tag_lightweight("tag-only", tagged_commit.as_object(), false).unwrap();
+        }
+        repo.reference("refs/heads/main", branch_tip, true, "test").unwrap();
+        repo.set_head("refs/heads/main").unwrap();
+
+        let walker = walked_walker(&path, 1, false);
+
+        let sorted_oids: StdHashSet<Oid> =
+            walker.oids.get_sorted_aliases().iter().filter_map(|alias| (!walker.oids.is_zero(walker.oids.get_gix_oid_by_alias(*alias))).then(|| walker.oids.get_oid_by_alias(*alias))).collect();
+
+        assert_eq!(sorted_oids, StdHashSet::from([root, branch_tip, tagged]));
+    }
+}
+
+#[test]
+fn gix_tag_oids_resolves_tags_without_collecting_other_refs() {
+    let (dir, repo) = temp_repo("gix-tag-oids");
+    let path = dir.join("repo");
+    let base = commit_file(&repo, "base.txt", "base", "base");
+    let tagged = commit_file_with_parents(&repo, "tagged.txt", "tagged", "tagged", &[], Some(100));
+    let base_commit = repo.find_commit(base).unwrap();
+    let tagged_commit = repo.find_commit(tagged).unwrap();
+    let tree = base_commit.tree().unwrap();
+    let sig = Signature::now("Test User", "test@example.com").unwrap();
+
+    repo.tag_lightweight("lightweight", base_commit.as_object(), false).unwrap();
+    repo.tag("annotated", tagged_commit.as_object(), &sig, "annotated", false).unwrap();
+    repo.tag_lightweight("tree-tag", tree.as_object(), false).unwrap();
+    repo.reference("refs/notes/not-a-tag", tagged, true, "test").unwrap();
+
+    let mut oids = Oids::default();
+    let gix_repo = gix::open(path).unwrap();
+    let tags = get_tag_oids(&gix_repo, &mut oids);
+
+    let base_alias = oids.get_existing_alias(base).unwrap();
+    let tagged_alias = oids.get_existing_alias(tagged).unwrap();
+    let names = tags.values().flatten().cloned().collect::<StdHashSet<_>>();
+
+    assert_eq!(tags.get(&base_alias).unwrap(), &vec!["lightweight".to_string()]);
+    assert_eq!(tags.get(&tagged_alias).unwrap(), &vec!["annotated".to_string()]);
+    assert!(!names.contains("tree-tag"));
+    assert!(!names.contains("not-a-tag"));
+}
+
+#[test]
+fn walker_new_handles_linked_worktree_startup_paths() {
+    let (_dir, _repo_path, linked_path, repo) = linked_worktree_startup_fixture("startup-linked-worktree");
+
+    let walker = Walker::new(linked_path.display().to_string(), 100, HashSet::new(), true, 20).unwrap();
+
+    assert!(walker.gix_repo.worktree().is_some());
+    assert_eq!(walker.gix_repo.common_dir(), repo.commondir());
+    assert!(walker.branches_local.values().flatten().any(|name| name == "main"));
+    assert!(walker.tags_local.values().flatten().any(|name| name == "v-main"));
+}
+
+#[test]
+fn walker_keeps_stash_adjacent_to_its_base_parent() {
+    let (dir, mut repo) = temp_repo("stash-order");
+    let path = dir.join("repo");
+    let base = commit_file(&repo, "file.txt", "base", "base");
+    let stash = stash_tracked_change(&mut repo, "file.txt", "stashed change", "stashed change");
+
+    let walker = walked_walker(&path, 100, false);
 
     let aliases = walker.oids.get_sorted_aliases();
-    let base_alias = walker.oids.aliases.get(&base).copied().unwrap();
-    let stash_alias = walker.oids.aliases.get(&stash).copied().unwrap();
+    let base_alias = walker.oids.get_existing_alias(base).unwrap();
+    let stash_alias = walker.oids.get_existing_alias(stash).unwrap();
     let base_idx = aliases.iter().position(|alias| *alias == base_alias).unwrap();
     let stash_idx = aliases.iter().position(|alias| *alias == stash_alias).unwrap();
 

--- a/src/tests/core/walker.rs
+++ b/src/tests/core/walker.rs
@@ -153,7 +153,7 @@ fn walker_expires_new_right_merge_lane_before_next_rendered_row() {
         .iter()
         .enumerate()
         .map(|(index, &alias)| {
-            let mut row = graph_row(index, alias, walker.oids.get_git2_oid_by_alias(alias));
+            let mut row = graph_row(index, alias, walker.oids.get_oid_by_alias(alias));
             row.is_merge = alias == merge_alias;
             row
         })

--- a/src/tests/core/walker.rs
+++ b/src/tests/core/walker.rs
@@ -1,31 +1,74 @@
 use super::*;
 use crate::{
-    core::{
-        graph_service::GraphRow,
-        oids::{Oids, gix_to_git2_oid},
-        renderers::render_graph_projection,
-    },
-    git::actions::worktrees::create_worktree,
-    git::queries::commits::get_tag_oids,
-    git::test_support::{TestDir, commit_file, commit_file_with_parents, stash_tracked_change, temp_repo},
+    core::{graph_service::GraphRow, renderers::render_graph_projection},
     helpers::{
         palette::Theme,
         symbols::{SymbolTheme, graph},
     },
 };
-use git2::{Oid, Repository, ResetType, Signature};
+use git2::{Oid, ResetType, Signature, Time};
 use ratatui::text::Line;
 use std::{
-    collections::HashSet as StdHashSet,
+    fs,
     path::{Path, PathBuf},
+    time::{SystemTime, UNIX_EPOCH},
 };
+
+fn temp_repo(name: &str) -> (PathBuf, Repository) {
+    let id = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
+    let path = std::env::temp_dir().join(format!("guitar-walker-reflog-{name}-{id}"));
+    fs::create_dir_all(&path).unwrap();
+    let repo = Repository::init(&path).unwrap();
+    {
+        let mut config = repo.config().unwrap();
+        config.set_str("user.name", "Test User").unwrap();
+        config.set_str("user.email", "test@example.com").unwrap();
+    }
+    (path, repo)
+}
+
+fn commit(repo: &Repository, file: &str, message: &str) -> Oid {
+    let workdir = repo.workdir().unwrap().to_path_buf();
+    fs::write(workdir.join(file), message).unwrap();
+
+    let mut index = repo.index().unwrap();
+    index.add_path(Path::new(file)).unwrap();
+    index.write().unwrap();
+    let tree_oid = index.write_tree().unwrap();
+    let tree = repo.find_tree(tree_oid).unwrap();
+    let sig = Signature::now("Test User", "test@example.com").unwrap();
+    let parent = repo.head().ok().and_then(|head| head.peel_to_commit().ok());
+    let parents: Vec<&git2::Commit<'_>> = parent.iter().collect();
+    repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &parents).unwrap()
+}
+
+fn stash_tracked_change(repo: &mut Repository, file: &str, message: &str) -> Oid {
+    let workdir = repo.workdir().unwrap().to_path_buf();
+    fs::write(workdir.join(file), message).unwrap();
+    let sig = repo.signature().unwrap();
+    repo.stash_save(&sig, message, None).unwrap()
+}
+
+fn commit_with_parents(repo: &Repository, file: &str, message: &str, parents: &[Oid], time: i64) -> Oid {
+    let workdir = repo.workdir().unwrap().to_path_buf();
+    fs::write(workdir.join(file), message).unwrap();
+
+    let mut index = repo.index().unwrap();
+    index.add_path(Path::new(file)).unwrap();
+    index.write().unwrap();
+    let tree_oid = index.write_tree().unwrap();
+    let tree = repo.find_tree(tree_oid).unwrap();
+    let sig = Signature::new("Test User", "test@example.com", &Time::new(time, 0)).unwrap();
+    let parent_commits: Vec<_> = parents.iter().map(|oid| repo.find_commit(*oid).unwrap()).collect();
+    let parent_refs: Vec<&git2::Commit<'_>> = parent_commits.iter().collect();
+    repo.commit(None, &sig, &sig, message, &tree, &parent_refs).unwrap()
+}
 
 fn graph_row(index: usize, alias: u32, oid: Oid) -> GraphRow {
     GraphRow {
         index,
         alias,
         oid,
-        short_oid: oid.to_string()[..9].to_string(),
         summary: String::new(),
         committer_date: String::new(),
         committer_name: String::new(),
@@ -36,7 +79,6 @@ fn graph_row(index: usize, alias: u32, oid: Oid) -> GraphRow {
         is_stash: false,
         stash_lane: None,
         worktrees: Vec::new(),
-        has_current_worktree: false,
         reflog: None,
     }
 }
@@ -45,118 +87,79 @@ fn line_text(line: &Line<'_>) -> String {
     line.spans.iter().map(|span| span.content.as_ref()).collect()
 }
 
-fn walked_walker(path: &Path, buffer_size: usize, include_head_reflog_roots: bool) -> Walker {
-    let mut walker = Walker::new(path.display().to_string(), buffer_size, HashSet::new(), include_head_reflog_roots, 20).unwrap();
-    while walker.walk() {}
-    walker
-}
-
-fn representative_graph_fixture(name: &str, tail_commits: usize) -> (TestDir, PathBuf, Repository) {
-    let (dir, repo) = temp_repo(name);
-    let path = dir.join("repo");
-    let root = commit_file(&repo, "root.txt", "root", "root");
-    let main_1 = commit_file_with_parents(&repo, "main.txt", "main-1", "main-1", &[root], Some(1));
-    let side_1 = commit_file_with_parents(&repo, "side.txt", "side-1", "side-1", &[root], Some(2));
-    let main_2 = commit_file_with_parents(&repo, "main.txt", "main-2", "main-2", &[main_1], Some(3));
-    let side_2 = commit_file_with_parents(&repo, "side.txt", "side-2", "side-2", &[side_1], Some(4));
-    let merge = commit_file_with_parents(&repo, "merge.txt", "merge", "merge", &[main_2, side_2], Some(5));
-
-    let mut tip = commit_file_with_parents(&repo, "tail.txt", "tail-0", "tail-0", &[merge], Some(6));
-    for idx in 1..tail_commits {
-        let value = format!("tail-{idx}");
-        tip = commit_file_with_parents(&repo, "tail.txt", &value, &value, &[tip], Some(6 + idx as i64));
-    }
-
-    repo.reference("refs/heads/main", tip, true, "test").unwrap();
-    repo.reference("refs/heads/feature", side_2, true, "test").unwrap();
-    repo.reference("refs/tags/v-main", main_1, true, "test").unwrap();
-    repo.set_head("refs/heads/main").unwrap();
-
-    (dir, path, repo)
-}
-
-fn linked_worktree_startup_fixture(name: &str) -> (TestDir, PathBuf, PathBuf, Repository) {
-    let (dir, path, repo) = representative_graph_fixture(name, 32);
-    let head = repo.head().unwrap().target().unwrap();
-    let linked_path = path.parent().unwrap_or_else(|| Path::new(".")).join(format!("{}-linked", path.file_name().and_then(|name| name.to_str()).unwrap_or("repo")));
-    create_worktree(&repo, "linked", &linked_path, head).unwrap();
-    (dir, path, linked_path, repo)
-}
-
 #[test]
 fn walker_loads_commit_reachable_only_from_head_reflog() {
-    let (dir, repo) = temp_repo("lost-root");
-    let path = dir.join("repo");
-    let base = commit_file(&repo, "file.txt", "base", "base");
-    let lost = commit_file(&repo, "file.txt", "lost", "lost");
+    let (path, repo) = temp_repo("lost-root");
+    let base = commit(&repo, "file.txt", "base");
+    let lost = commit(&repo, "file.txt", "lost");
     let base_commit = repo.find_commit(base).unwrap();
     repo.reset(base_commit.as_object(), ResetType::Hard, None).unwrap();
 
-    let walker = walked_walker(&path, 100, true);
-    let lost_alias = walker.oids.get_existing_alias(lost).unwrap();
+    let mut walker = Walker::new(path.display().to_string(), 100, HashSet::new(), true, 20).unwrap();
+    walker.walk();
+    let lost_alias = walker.oids.aliases.get(&lost).copied().unwrap();
 
     assert!(walker.oids.get_sorted_aliases().contains(&lost_alias));
 }
 
 #[test]
 fn walker_can_hide_commit_reachable_only_from_head_reflog() {
-    let (dir, repo) = temp_repo("hidden-lost-root");
-    let path = dir.join("repo");
-    let base = commit_file(&repo, "file.txt", "base", "base");
-    let lost = commit_file(&repo, "file.txt", "lost", "lost");
+    let (path, repo) = temp_repo("hidden-lost-root");
+    let base = commit(&repo, "file.txt", "base");
+    let lost = commit(&repo, "file.txt", "lost");
     let base_commit = repo.find_commit(base).unwrap();
     repo.reset(base_commit.as_object(), ResetType::Hard, None).unwrap();
 
-    let walker = walked_walker(&path, 100, false);
-    let lost_alias = walker.oids.get_existing_alias(lost).unwrap();
+    let mut walker = Walker::new(path.display().to_string(), 100, HashSet::new(), false, 20).unwrap();
+    walker.walk();
+    let lost_alias = walker.oids.aliases.get(&lost).copied().unwrap();
 
     assert!(!walker.oids.get_sorted_aliases().contains(&lost_alias));
-    assert!(walker.head_reflog_entries.iter().any(|entry| gix_to_git2_oid(entry.new_oid) == lost));
+    assert!(walker.head_reflog_entries.iter().any(|entry| entry.new_oid == lost));
 }
 
 #[test]
 fn walker_expires_new_right_merge_lane_before_next_rendered_row() {
-    let (dir, repo) = temp_repo("transient-merge-lane");
-    let path = dir.join("repo");
-    let root = commit_file_with_parents(&repo, "root.txt", "root", "root", &[], Some(1));
-    let left_parent = commit_file_with_parents(&repo, "left-parent.txt", "left parent", "left parent", &[root], Some(2));
-    let right_parent = commit_file_with_parents(&repo, "right-parent.txt", "right parent", "right parent", &[root], Some(3));
-    let merge = commit_file_with_parents(&repo, "merge.txt", "merge", "merge", &[left_parent, right_parent], Some(4));
-    let right_tip = commit_file_with_parents(&repo, "right-tip.txt", "right tip", "right tip", &[right_parent], Some(5));
-    let left_tip = commit_file_with_parents(&repo, "left-tip.txt", "left tip", "left tip", &[left_parent], Some(6));
+    let (path, repo) = temp_repo("transient-merge-lane");
+    let root = commit_with_parents(&repo, "root.txt", "root", &[], 1);
+    let left_parent = commit_with_parents(&repo, "left-parent.txt", "left parent", &[root], 2);
+    let right_parent = commit_with_parents(&repo, "right-parent.txt", "right parent", &[root], 3);
+    let merge = commit_with_parents(&repo, "merge.txt", "merge", &[left_parent, right_parent], 4);
+    let right_tip = commit_with_parents(&repo, "right-tip.txt", "right tip", &[right_parent], 5);
+    let left_tip = commit_with_parents(&repo, "left-tip.txt", "left tip", &[left_parent], 6);
 
     repo.reference("refs/heads/main", left_tip, true, "test").unwrap();
     repo.reference("refs/heads/right", right_tip, true, "test").unwrap();
     repo.reference("refs/heads/merge", merge, true, "test").unwrap();
     repo.set_head("refs/heads/main").unwrap();
 
-    let walker = walked_walker(&path, 100, false);
+    let mut walker = Walker::new(path.display().to_string(), 100, HashSet::new(), false, 20).unwrap();
+    while walker.walk() {}
 
-    let merge_alias = walker.oids.get_existing_alias(merge).unwrap();
-    let head_alias = walker.oids.get_existing_alias(left_tip).unwrap();
+    let merge_alias = walker.oids.aliases.get(&merge).copied().unwrap();
+    let head_alias = walker.oids.aliases.get(&left_tip).copied().unwrap();
     let aliases = walker.oids.get_sorted_aliases().clone();
     let merge_idx = aliases.iter().position(|alias| *alias == merge_alias).unwrap();
     assert!(merge_idx + 1 < aliases.len());
 
     let history = walker.buffer.borrow().window(0, aliases.len().saturating_add(1));
     let merge_history_idx = merge_idx;
-    let merge_lane = history.get(merge_history_idx).unwrap().iter().position(|chunk| chunk.alias == merge_alias).unwrap();
+    let merge_lane = history[merge_history_idx].iter().position(|chunk| chunk.alias == merge_alias).unwrap();
 
-    assert_eq!(merge_lane + 1, history.get(merge_history_idx).unwrap().len());
-    assert!(history.get(merge_history_idx + 1).unwrap().get(merge_lane).is_none());
+    assert_eq!(merge_lane + 1, history[merge_history_idx].len());
+    assert!(history[merge_history_idx + 1].get(merge_lane).is_none());
 
     let rows: Vec<_> = aliases
         .iter()
         .enumerate()
         .map(|(index, &alias)| {
-            let mut row = graph_row(index, alias, walker.oids.get_oid_by_alias(alias));
+            let mut row = graph_row(index, alias, *walker.oids.get_oid_by_alias(alias));
             row.is_merge = alias == merge_alias;
             row
         })
         .collect();
     let symbols = SymbolTheme::main();
-    let theme = Theme::classic();
-    let lines = render_graph_projection(&theme, &symbols, &rows, &history, head_alias, 0, aliases.len(), true);
+    let lines = render_graph_projection(&Theme::classic(), &symbols, &rows, &history, head_alias, 0, aliases.len(), true);
     let merge_text = line_text(&lines[merge_idx]);
     let next_text = line_text(&lines[merge_idx + 1]);
     let merge_col = merge_text.chars().position(|ch| ch == graph::MERGE.chars().next().unwrap()).unwrap();
@@ -166,19 +169,19 @@ fn walker_expires_new_right_merge_lane_before_next_rendered_row() {
 
 #[test]
 fn walker_records_ref_stash_and_reflog_lanes_from_update_lane() {
-    let (dir, mut repo) = temp_repo("cached-lanes");
-    let path = dir.join("repo");
-    let base = commit_file(&repo, "file.txt", "base", "base");
+    let (path, mut repo) = temp_repo("cached-lanes");
+    let base = commit(&repo, "file.txt", "base");
     {
         let base_commit = repo.find_commit(base).unwrap();
         repo.tag_lightweight("v-base", base_commit.as_object(), false).unwrap();
     }
-    let stash = stash_tracked_change(&mut repo, "file.txt", "stashed change", "stashed change");
+    let stash = stash_tracked_change(&mut repo, "file.txt", "stashed change");
 
-    let walker = walked_walker(&path, 100, true);
+    let mut walker = Walker::new(path.display().to_string(), 100, HashSet::new(), true, 20).unwrap();
+    while walker.walk() {}
 
-    let base_alias = walker.oids.get_existing_alias(base).unwrap();
-    let stash_alias = walker.oids.get_existing_alias(stash).unwrap();
+    let base_alias = walker.oids.aliases.get(&base).copied().unwrap();
+    let stash_alias = walker.oids.aliases.get(&stash).copied().unwrap();
 
     assert!(walker.branches_lanes.contains_key(&base_alias));
     assert!(walker.tags_lanes.contains_key(&base_alias));
@@ -187,102 +190,17 @@ fn walker_records_ref_stash_and_reflog_lanes_from_update_lane() {
 }
 
 #[test]
-fn walker_new_collects_startup_metadata_before_walking() {
-    let (_dir, path, mut repo) = representative_graph_fixture("startup-metadata", 32);
-    let stash = stash_tracked_change(&mut repo, "tail.txt", "stashed change", "stashed change");
-
-    let walker = Walker::new(path.display().to_string(), 100, HashSet::new(), true, 20).unwrap();
-
-    assert!(walker.branches_local.values().flatten().any(|name| name == "main"));
-    assert!(walker.branches_local.values().flatten().any(|name| name == "feature"));
-    assert!(walker.tags_local.values().flatten().any(|name| name == "v-main"));
-    assert!(!walker.oids.stashes.is_empty());
-    assert!(walker.oids.get_existing_alias(stash).is_some());
-    assert!(!walker.head_reflog_entries.is_empty());
-}
-
-#[test]
-fn walker_matches_rev_list_all_for_lightweight_and_annotated_tags() {
-    for annotated in [false, true] {
-        let (dir, repo) = temp_repo(if annotated { "annotated-tag-root" } else { "tag-only-root" });
-        let path = dir.join("repo");
-        let root = commit_file(&repo, "root.txt", "root", "root");
-        let branch_tip = commit_file(&repo, "branch.txt", "branch", "branch");
-        let tagged = commit_file_with_parents(&repo, "tagged.txt", "tagged", "tagged", &[], Some(if annotated { 100 } else { 99 }));
-        let tagged_commit = repo.find_commit(tagged).unwrap();
-
-        if annotated {
-            let sig = Signature::now("Test User", "test@example.com").unwrap();
-            repo.tag("annotated", tagged_commit.as_object(), &sig, "annotated", false).unwrap();
-        } else {
-            repo.tag_lightweight("tag-only", tagged_commit.as_object(), false).unwrap();
-        }
-        repo.reference("refs/heads/main", branch_tip, true, "test").unwrap();
-        repo.set_head("refs/heads/main").unwrap();
-
-        let walker = walked_walker(&path, 1, false);
-
-        let sorted_oids: StdHashSet<Oid> =
-            walker.oids.get_sorted_aliases().iter().filter_map(|alias| (!walker.oids.is_zero(walker.oids.get_gix_oid_by_alias(*alias))).then(|| walker.oids.get_oid_by_alias(*alias))).collect();
-
-        assert_eq!(sorted_oids, StdHashSet::from([root, branch_tip, tagged]));
-    }
-}
-
-#[test]
-fn gix_tag_oids_resolves_tags_without_collecting_other_refs() {
-    let (dir, repo) = temp_repo("gix-tag-oids");
-    let path = dir.join("repo");
-    let base = commit_file(&repo, "base.txt", "base", "base");
-    let tagged = commit_file_with_parents(&repo, "tagged.txt", "tagged", "tagged", &[], Some(100));
-    let base_commit = repo.find_commit(base).unwrap();
-    let tagged_commit = repo.find_commit(tagged).unwrap();
-    let tree = base_commit.tree().unwrap();
-    let sig = Signature::now("Test User", "test@example.com").unwrap();
-
-    repo.tag_lightweight("lightweight", base_commit.as_object(), false).unwrap();
-    repo.tag("annotated", tagged_commit.as_object(), &sig, "annotated", false).unwrap();
-    repo.tag_lightweight("tree-tag", tree.as_object(), false).unwrap();
-    repo.reference("refs/notes/not-a-tag", tagged, true, "test").unwrap();
-
-    let mut oids = Oids::default();
-    let gix_repo = gix::open(path).unwrap();
-    let tags = get_tag_oids(&gix_repo, &mut oids);
-
-    let base_alias = oids.get_existing_alias(base).unwrap();
-    let tagged_alias = oids.get_existing_alias(tagged).unwrap();
-    let names = tags.values().flatten().cloned().collect::<StdHashSet<_>>();
-
-    assert_eq!(tags.get(&base_alias).unwrap(), &vec!["lightweight".to_string()]);
-    assert_eq!(tags.get(&tagged_alias).unwrap(), &vec!["annotated".to_string()]);
-    assert!(!names.contains("tree-tag"));
-    assert!(!names.contains("not-a-tag"));
-}
-
-#[test]
-fn walker_new_handles_linked_worktree_startup_paths() {
-    let (_dir, _repo_path, linked_path, repo) = linked_worktree_startup_fixture("startup-linked-worktree");
-
-    let walker = Walker::new(linked_path.display().to_string(), 100, HashSet::new(), true, 20).unwrap();
-
-    assert!(walker.gix_repo.worktree().is_some());
-    assert_eq!(walker.gix_repo.common_dir(), repo.commondir());
-    assert!(walker.branches_local.values().flatten().any(|name| name == "main"));
-    assert!(walker.tags_local.values().flatten().any(|name| name == "v-main"));
-}
-
-#[test]
 fn walker_keeps_stash_adjacent_to_its_base_parent() {
-    let (dir, mut repo) = temp_repo("stash-order");
-    let path = dir.join("repo");
-    let base = commit_file(&repo, "file.txt", "base", "base");
-    let stash = stash_tracked_change(&mut repo, "file.txt", "stashed change", "stashed change");
+    let (path, mut repo) = temp_repo("stash-order");
+    let base = commit(&repo, "file.txt", "base");
+    let stash = stash_tracked_change(&mut repo, "file.txt", "stashed change");
 
-    let walker = walked_walker(&path, 100, false);
+    let mut walker = Walker::new(path.display().to_string(), 100, HashSet::new(), false, 20).unwrap();
+    while walker.walk() {}
 
     let aliases = walker.oids.get_sorted_aliases();
-    let base_alias = walker.oids.get_existing_alias(base).unwrap();
-    let stash_alias = walker.oids.get_existing_alias(stash).unwrap();
+    let base_alias = walker.oids.aliases.get(&base).copied().unwrap();
+    let stash_alias = walker.oids.aliases.get(&stash).copied().unwrap();
     let base_idx = aliases.iter().position(|alias| *alias == base_alias).unwrap();
     let stash_idx = aliases.iter().position(|alias| *alias == stash_alias).unwrap();
 

--- a/src/tests/core/walker.rs
+++ b/src/tests/core/walker.rs
@@ -97,7 +97,7 @@ fn walker_loads_commit_reachable_only_from_head_reflog() {
 
     let mut walker = Walker::new(path.display().to_string(), 100, HashSet::new(), true, 20).unwrap();
     walker.walk();
-    let lost_alias = walker.oids.aliases.get(&lost).copied().unwrap();
+    let lost_alias = walker.oids.get_existing_alias(lost).unwrap();
 
     assert!(walker.oids.get_sorted_aliases().contains(&lost_alias));
 }
@@ -112,7 +112,7 @@ fn walker_can_hide_commit_reachable_only_from_head_reflog() {
 
     let mut walker = Walker::new(path.display().to_string(), 100, HashSet::new(), false, 20).unwrap();
     walker.walk();
-    let lost_alias = walker.oids.aliases.get(&lost).copied().unwrap();
+    let lost_alias = walker.oids.get_existing_alias(lost).unwrap();
 
     assert!(!walker.oids.get_sorted_aliases().contains(&lost_alias));
     assert!(walker.head_reflog_entries.iter().any(|entry| entry.new_oid == lost));
@@ -136,9 +136,9 @@ fn walker_expires_new_right_merge_lane_before_next_rendered_row() {
     let mut walker = Walker::new(path.display().to_string(), 100, HashSet::new(), false, 20).unwrap();
     while walker.walk() {}
 
-    let merge_alias = walker.oids.aliases.get(&merge).copied().unwrap();
-    let head_alias = walker.oids.aliases.get(&left_tip).copied().unwrap();
-    let aliases = walker.oids.get_sorted_aliases().clone();
+    let merge_alias = walker.oids.get_existing_alias(merge).unwrap();
+    let head_alias = walker.oids.get_existing_alias(left_tip).unwrap();
+    let aliases = walker.oids.get_sorted_aliases();
     let merge_idx = aliases.iter().position(|alias| *alias == merge_alias).unwrap();
     assert!(merge_idx + 1 < aliases.len());
 
@@ -153,7 +153,7 @@ fn walker_expires_new_right_merge_lane_before_next_rendered_row() {
         .iter()
         .enumerate()
         .map(|(index, &alias)| {
-            let mut row = graph_row(index, alias, *walker.oids.get_oid_by_alias(alias));
+            let mut row = graph_row(index, alias, walker.oids.get_git2_oid_by_alias(alias));
             row.is_merge = alias == merge_alias;
             row
         })
@@ -180,8 +180,8 @@ fn walker_records_ref_stash_and_reflog_lanes_from_update_lane() {
     let mut walker = Walker::new(path.display().to_string(), 100, HashSet::new(), true, 20).unwrap();
     while walker.walk() {}
 
-    let base_alias = walker.oids.aliases.get(&base).copied().unwrap();
-    let stash_alias = walker.oids.aliases.get(&stash).copied().unwrap();
+    let base_alias = walker.oids.get_existing_alias(base).unwrap();
+    let stash_alias = walker.oids.get_existing_alias(stash).unwrap();
 
     assert!(walker.branches_lanes.contains_key(&base_alias));
     assert!(walker.tags_lanes.contains_key(&base_alias));
@@ -199,8 +199,8 @@ fn walker_keeps_stash_adjacent_to_its_base_parent() {
     while walker.walk() {}
 
     let aliases = walker.oids.get_sorted_aliases();
-    let base_alias = walker.oids.aliases.get(&base).copied().unwrap();
-    let stash_alias = walker.oids.aliases.get(&stash).copied().unwrap();
+    let base_alias = walker.oids.get_existing_alias(base).unwrap();
+    let stash_alias = walker.oids.get_existing_alias(stash).unwrap();
     let base_idx = aliases.iter().position(|alias| *alias == base_alias).unwrap();
     let stash_idx = aliases.iter().position(|alias| *alias == stash_alias).unwrap();
 

--- a/src/tests/git/actions/branching.rs
+++ b/src/tests/git/actions/branching.rs
@@ -11,12 +11,7 @@ fn temp_repo(name: &str) -> (PathBuf, Repository) {
     let id = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
     let path = std::env::temp_dir().join(format!("guitar-branch-actions-{name}-{id}"));
     fs::create_dir_all(&path).unwrap();
-    let repo = Repository::init(&path).unwrap();
-    {
-        let mut config = repo.config().unwrap();
-        config.set_str("user.name", "Test User").unwrap();
-        config.set_str("user.email", "test@example.com").unwrap();
-    }
+    let repo = crate::git::test_support::init_repo_at(&path);
     (path, repo)
 }
 

--- a/src/tests/git/actions/cherrypicking.rs
+++ b/src/tests/git/actions/cherrypicking.rs
@@ -10,12 +10,7 @@ fn temp_repo(name: &str) -> (PathBuf, Repository) {
     let id = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
     let path = std::env::temp_dir().join(format!("guitar-cherrypick-{name}-{id}"));
     fs::create_dir_all(&path).unwrap();
-    let repo = Repository::init(&path).unwrap();
-    {
-        let mut config = repo.config().unwrap();
-        config.set_str("user.name", "Test User").unwrap();
-        config.set_str("user.email", "test@example.com").unwrap();
-    }
+    let repo = crate::git::test_support::init_repo_at(&path);
     (path, repo)
 }
 

--- a/src/tests/git/actions/merging.rs
+++ b/src/tests/git/actions/merging.rs
@@ -10,12 +10,7 @@ fn temp_repo(name: &str) -> (PathBuf, Repository) {
     let id = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
     let path = std::env::temp_dir().join(format!("guitar-merge-{name}-{id}"));
     fs::create_dir_all(&path).unwrap();
-    let repo = Repository::init(&path).unwrap();
-    {
-        let mut config = repo.config().unwrap();
-        config.set_str("user.name", "Test User").unwrap();
-        config.set_str("user.email", "test@example.com").unwrap();
-    }
+    let repo = crate::git::test_support::init_repo_at(&path);
     (path, repo)
 }
 

--- a/src/tests/git/actions/rebasing.rs
+++ b/src/tests/git/actions/rebasing.rs
@@ -10,12 +10,7 @@ fn temp_repo(name: &str) -> (PathBuf, Repository) {
     let id = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
     let path = std::env::temp_dir().join(format!("guitar-rebase-{name}-{id}"));
     fs::create_dir_all(&path).unwrap();
-    let repo = Repository::init(&path).unwrap();
-    {
-        let mut config = repo.config().unwrap();
-        config.set_str("user.name", "Test User").unwrap();
-        config.set_str("user.email", "test@example.com").unwrap();
-    }
+    let repo = crate::git::test_support::init_repo_at(&path);
     (path, repo)
 }
 

--- a/src/tests/git/actions/reverting.rs
+++ b/src/tests/git/actions/reverting.rs
@@ -10,12 +10,7 @@ fn temp_repo(name: &str) -> (PathBuf, Repository) {
     let id = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
     let path = std::env::temp_dir().join(format!("guitar-revert-{name}-{id}"));
     fs::create_dir_all(&path).unwrap();
-    let repo = Repository::init(&path).unwrap();
-    {
-        let mut config = repo.config().unwrap();
-        config.set_str("user.name", "Test User").unwrap();
-        config.set_str("user.email", "test@example.com").unwrap();
-    }
+    let repo = crate::git::test_support::init_repo_at(&path);
     (path, repo)
 }
 

--- a/src/tests/git/queries/diffs.rs
+++ b/src/tests/git/queries/diffs.rs
@@ -34,12 +34,7 @@ fn temp_repo(name: &str) -> (PathBuf, Repository) {
     let id = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
     let path = std::env::temp_dir().join(format!("guitar-diff-{name}-{id}"));
     fs::create_dir_all(&path).unwrap();
-    let repo = Repository::init(&path).unwrap();
-    {
-        let mut config = repo.config().unwrap();
-        config.set_str("user.name", "Test User").unwrap();
-        config.set_str("user.email", "test@example.com").unwrap();
-    }
+    let repo = crate::git::test_support::init_repo_at(&path);
     (path, repo)
 }
 
@@ -64,7 +59,7 @@ fn commit_index(repo: &Repository, message: &str) -> Oid {
     repo.commit(Some("HEAD"), &sig, &sig, message, &tree, &parents).unwrap()
 }
 
-fn init_repo_at(path: &Path) -> Repository {
+fn init_seeded_repo_at(path: &Path) -> Repository {
     fs::create_dir_all(path).unwrap();
     let repo = Repository::init(path).unwrap();
     {
@@ -80,9 +75,9 @@ fn init_repo_at(path: &Path) -> Repository {
 fn parent_with_submodule(dir: &TestDir) -> Repository {
     let child_path = dir.path.join("child");
     let parent_path = dir.path.join("parent");
-    let child = init_repo_at(&child_path);
+    let child = init_seeded_repo_at(&child_path);
     drop(child);
-    let parent = init_repo_at(&parent_path);
+    let parent = init_seeded_repo_at(&parent_path);
     let mut submodule = parent.submodule(child_path.to_str().unwrap(), Path::new("deps/child"), true).unwrap();
     submodule.clone(None).unwrap();
     submodule.add_finalize().unwrap();

--- a/src/tests/git/queries/remotes.rs
+++ b/src/tests/git/queries/remotes.rs
@@ -10,7 +10,7 @@ fn temp_repo(name: &str) -> (std::path::PathBuf, Repository) {
     let id = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
     let path = std::env::temp_dir().join(format!("guitar-remote-query-{name}-{id}"));
     fs::create_dir_all(&path).unwrap();
-    let repo = Repository::init(&path).unwrap();
+    let repo = crate::git::test_support::init_repo_at(&path);
     (path, repo)
 }
 

--- a/src/tests/helpers/heatmap.rs
+++ b/src/tests/helpers/heatmap.rs
@@ -1,0 +1,58 @@
+use super::*;
+use crate::core::oids::git2_to_gix_oid as gix_oid;
+use git2::{IndexAddOption, Oid, Repository, Signature, Time};
+use std::fs;
+
+fn commit_at(repo: &Repository, name: &str, seconds: i64) -> Oid {
+    fs::write(repo.workdir().unwrap().join(name), name).unwrap();
+
+    let mut index = repo.index().unwrap();
+    index.add_all(["."], IndexAddOption::DEFAULT, None).unwrap();
+    index.write().unwrap();
+    let tree_oid = index.write_tree().unwrap();
+    let tree = repo.find_tree(tree_oid).unwrap();
+    let sig = Signature::new("Test User", "test@example.com", &Time::new(seconds, 0)).unwrap();
+    let parent = repo.head().ok().and_then(|head| head.peel_to_commit().ok());
+    let parents: Vec<&git2::Commit<'_>> = parent.iter().collect();
+
+    repo.commit(Some("HEAD"), &sig, &sig, name, &tree, &parents).unwrap()
+}
+
+#[test]
+fn heatmap_counts_repo_and_streamed_commits() {
+    let dir = tempfile::Builder::new().prefix("guitar-heatmap-").tempdir().unwrap();
+    let repo = Repository::init(dir.path()).unwrap();
+    let now = Utc::now();
+    let today = now.timestamp();
+    let yesterday = today - 24 * 60 * 60;
+    let outside_grid = today - ((TOTAL_DAYS as i64) + 10) * 24 * 60 * 60;
+    let first_today = commit_at(&repo, "first-today.txt", today);
+    let second_today = commit_at(&repo, "second-today.txt", today);
+    let yesterday_oid = commit_at(&repo, "yesterday.txt", yesterday);
+    let old = commit_at(&repo, "old.txt", outside_grid);
+
+    let gix_repo = gix::open(dir.path()).unwrap();
+    let weekday_today = now.weekday().num_days_from_monday() as usize;
+    let counts = commits_per_day(&gix_repo, [first_today, second_today, old].map(gix_oid));
+    let stopped = commits_per_day(&gix_repo, [first_today, old, second_today].map(gix_oid));
+    let grid = build_heatmap(&gix_repo, [gix_oid(first_today)]);
+
+    assert_eq!(counts[0], 2);
+    assert_eq!(counts.iter().sum::<usize>(), 2);
+    assert_eq!(stopped[0], 2);
+    assert_eq!(stopped.iter().sum::<usize>(), 2);
+    assert_eq!(grid[weekday_today][WEEKS - 1], 1);
+
+    let scanned = build_heatmap(&gix_repo, [first_today, yesterday_oid].map(gix_oid));
+    let mut streamed = HeatmapCounts::default();
+    streamed.add_commit_seconds(today);
+    streamed.add_commit_seconds(yesterday);
+
+    let mut filtered = HeatmapCounts::default();
+    filtered.add_commit_seconds(today);
+    filtered.add_commit_seconds(outside_grid);
+    filtered.add_commit_seconds(today + 24 * 60 * 60);
+
+    assert_eq!(streamed.build(), scanned);
+    assert_eq!(filtered.build().iter().flatten().sum::<usize>(), 1);
+}

--- a/src/tests/helpers/heatmap.rs
+++ b/src/tests/helpers/heatmap.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate::core::oids::git2_to_gix_oid as gix_oid;
 use git2::{IndexAddOption, Oid, Repository, Signature, Time};
 use std::fs;
 
@@ -31,13 +30,12 @@ fn heatmap_counts_repo_and_streamed_commits() {
     let yesterday_oid = commit_at(&repo, "yesterday.txt", yesterday);
     let old = commit_at(&repo, "old.txt", outside_grid);
 
-    let gix_repo = gix::open(dir.path()).unwrap();
     let weekday_today = now.weekday().num_days_from_monday() as usize;
-    let counts = commits_per_day(&gix_repo, [first_today, second_today, old].map(gix_oid));
-    let stopped = commits_per_day(&gix_repo, [first_today, old, second_today].map(gix_oid));
-    let grid = build_heatmap(&gix_repo, [gix_oid(first_today)]);
+    let counts = commits_per_day(&repo, [first_today, second_today, old]);
+    let stopped = commits_per_day(&repo, [first_today, old, second_today]);
+    let grid = build_heatmap(&repo, [first_today]);
 
-    let scanned = build_heatmap(&gix_repo, [first_today, yesterday_oid].map(gix_oid));
+    let scanned = build_heatmap(&repo, [first_today, yesterday_oid]);
 
     assert_eq!(counts[0], 2);
     assert_eq!(counts.iter().sum::<usize>(), 2);
@@ -56,8 +54,7 @@ fn heatmap_counts_match_streamed_helper() {
     let first_today = commit_at(&repo, "first-today.txt", today);
     let yesterday_oid = commit_at(&repo, "yesterday.txt", yesterday);
 
-    let gix_repo = gix::open(dir.path()).unwrap();
-    let scanned = build_heatmap(&gix_repo, [first_today, yesterday_oid].map(gix_oid));
+    let scanned = build_heatmap(&repo, [first_today, yesterday_oid]);
     let mut streamed = HeatmapCounts::default();
     streamed.add_commit_seconds(today);
     streamed.add_commit_seconds(yesterday);
@@ -83,7 +80,7 @@ fn prefix_matching_accepts_partial_hex() {
     let dir = tempfile::Builder::new().prefix("guitar-prefix-").tempdir().unwrap();
     let repo = Repository::init(dir.path()).unwrap();
     let oid = commit_at(&repo, "prefix.txt", Utc::now().timestamp());
-    let gix_oid = gix_oid(oid);
+    let gix_oid = crate::core::oids::git2_to_gix_oid(oid);
     let mut oids = crate::core::oids::Oids::default();
 
     let alias = oids.get_alias_by_oid(gix_oid);

--- a/src/tests/helpers/heatmap.rs
+++ b/src/tests/helpers/heatmap.rs
@@ -37,22 +37,57 @@ fn heatmap_counts_repo_and_streamed_commits() {
     let stopped = commits_per_day(&gix_repo, [first_today, old, second_today].map(gix_oid));
     let grid = build_heatmap(&gix_repo, [gix_oid(first_today)]);
 
+    let scanned = build_heatmap(&gix_repo, [first_today, yesterday_oid].map(gix_oid));
+
     assert_eq!(counts[0], 2);
     assert_eq!(counts.iter().sum::<usize>(), 2);
     assert_eq!(stopped[0], 2);
     assert_eq!(stopped.iter().sum::<usize>(), 2);
     assert_eq!(grid[weekday_today][WEEKS - 1], 1);
+    assert_eq!(scanned[weekday_today][WEEKS - 1], 1);
+}
 
+#[test]
+fn heatmap_counts_match_streamed_helper() {
+    let dir = tempfile::Builder::new().prefix("guitar-heatmap-stream-").tempdir().unwrap();
+    let repo = Repository::init(dir.path()).unwrap();
+    let today = Utc::now().timestamp();
+    let yesterday = today - 24 * 60 * 60;
+    let first_today = commit_at(&repo, "first-today.txt", today);
+    let yesterday_oid = commit_at(&repo, "yesterday.txt", yesterday);
+
+    let gix_repo = gix::open(dir.path()).unwrap();
     let scanned = build_heatmap(&gix_repo, [first_today, yesterday_oid].map(gix_oid));
     let mut streamed = HeatmapCounts::default();
     streamed.add_commit_seconds(today);
     streamed.add_commit_seconds(yesterday);
 
-    let mut filtered = HeatmapCounts::default();
-    filtered.add_commit_seconds(today);
-    filtered.add_commit_seconds(outside_grid);
-    filtered.add_commit_seconds(today + 24 * 60 * 60);
-
     assert_eq!(streamed.build(), scanned);
-    assert_eq!(filtered.build().iter().flatten().sum::<usize>(), 1);
+}
+
+#[test]
+fn heatmap_counts_ignore_out_of_range_commits() {
+    let mut counts = HeatmapCounts::default();
+    let today = Utc::now().timestamp();
+    let outside_grid = today - ((TOTAL_DAYS as i64) + 10) * 24 * 60 * 60;
+
+    counts.add_commit_seconds(today);
+    counts.add_commit_seconds(outside_grid);
+    counts.add_commit_seconds(today + 24 * 60 * 60);
+
+    assert_eq!(counts.build().iter().flatten().sum::<usize>(), 1);
+}
+
+#[test]
+fn prefix_matching_accepts_partial_hex() {
+    let dir = tempfile::Builder::new().prefix("guitar-prefix-").tempdir().unwrap();
+    let repo = Repository::init(dir.path()).unwrap();
+    let oid = commit_at(&repo, "prefix.txt", Utc::now().timestamp());
+    let gix_oid = gix_oid(oid);
+    let mut oids = crate::core::oids::Oids::default();
+
+    let alias = oids.get_alias_by_oid(gix_oid);
+
+    assert_eq!(oids.get_alias_by_prefix(&gix_oid.to_hex_with_len(7).to_string()), Some(alias));
+    assert_eq!(oids.get_alias_by_prefix("not-hex"), None);
 }

--- a/src/tests/helpers/keymap.rs
+++ b/src/tests/helpers/keymap.rs
@@ -552,6 +552,8 @@ fn keymaps_round_trip_through_disk() {
 
 #[test]
 fn keymap_config_serialization_stays_english_while_visual_labels_localise() {
+    let _guard = crate::git::test_support::language_test_guard();
+
     crate::helpers::localisation::set_active_language(crate::helpers::localisation::Language::Spanish);
     assert_eq!(command_to_visual_string(&Command::ScrollDown), "Desplazar abajo");
 
@@ -568,6 +570,4 @@ fn keymap_config_serialization_stays_english_while_visual_labels_localise() {
 
     assert!(contents.contains("\"command\": \"ScrollDown\""), "{contents}");
     assert!(!contents.contains("Desplazar"), "{contents}");
-
-    crate::helpers::localisation::set_active_language(crate::helpers::localisation::Language::English);
 }

--- a/src/tests/helpers/localisation.rs
+++ b/src/tests/helpers/localisation.rs
@@ -1,12 +1,9 @@
 use super::*;
-use std::{
-    fs,
-    time::{SystemTime, UNIX_EPOCH},
-};
+use crate::git::test_support::language_test_guard;
+use std::fs;
 
 fn temp_language_path(name: &str) -> std::path::PathBuf {
-    let id = SystemTime::now().duration_since(UNIX_EPOCH).unwrap().as_nanos();
-    std::env::temp_dir().join(format!("guitar-language-{name}-{id}.json"))
+    tempfile::Builder::new().prefix(&format!("guitar-language-{name}-")).suffix(".json").tempfile().unwrap().into_temp_path().keep().unwrap()
 }
 
 #[test]
@@ -41,6 +38,8 @@ fn invalid_language_file_falls_back_to_english() {
 
 #[test]
 fn active_language_changes_localised_text() {
+    let _guard = language_test_guard();
+
     set_active_language(Language::English);
     assert_eq!(menu::SETTINGS(), "Settings");
 
@@ -52,6 +51,8 @@ fn active_language_changes_localised_text() {
 
 #[test]
 fn settings_general_performance_lane_limit_text_is_localised() {
+    let _guard = language_test_guard();
+
     for (language, general, performance, lane_limit, prompt) in [
         (Language::English, "general", " performance:", " graph lane limit:", "Enter graph lane limit"),
         (Language::Spanish, "general", " rendimiento:", " límite de carriles del grafo:", "Introduce límite de carriles del grafo"),
@@ -73,6 +74,8 @@ fn settings_general_performance_lane_limit_text_is_localised() {
 fn graph_lane_limit_shortcut_command_labels_are_localised() {
     use crate::helpers::keymap::{Command, command_to_visual_string};
 
+    let _guard = language_test_guard();
+
     for (language, shrink, grow) in [
         (Language::English, "Shrink graph lane limit", "Grow graph lane limit"),
         (Language::Spanish, "Reducir límite de carriles del grafo", "Aumentar límite de carriles del grafo"),
@@ -90,6 +93,8 @@ fn graph_lane_limit_shortcut_command_labels_are_localised() {
 
 #[test]
 fn formatted_messages_keep_runtime_values() {
+    let _guard = language_test_guard();
+
     set_active_language(Language::Turkish);
     assert!(network::pushing("main", "origin").contains("main"));
     assert!(network::pushing("main", "origin").contains("origin"));


### PR DESCRIPTION
Stacked on `mjc/gitoxide-spike-01-gix-boundary`.

Why this PR exists:

- PR 1 added the gitoxide and `iddqd` dependencies.
- This PR starts using them for commit identity storage.
- The old `Oids` structure stored raw `git2::Oid` values in a `Vec` and used a `HashMap<git2::Oid, u32>` for alias lookup.
- This PR moves the internal OID store to `gix::ObjectId`, stores alias records in an `iddqd::IdHashMap`, and keeps the public alias path centered on small `u32` aliases.
- The app still has `git2` call sites, so this is not a full gitoxide migration yet. It is the commit-identity storage layer that lets later PRs keep moving the graph/query code toward gix-backed data.

What changed:

- Replaces `Oids` internals with:
  - `gix::ObjectId` for stored object IDs.
  - `IdHashMap<OidRecord>` for OID → alias lookup.
  - `Vec<ObjectId>` for alias → OID lookup.
- Adds explicit `git2` ↔ `gix` OID conversion helpers.
- Adds `IntoGixOid` so existing `git2::Oid` call sites can cross the boundary while the rest of the stack is migrated.
- Adds `get_existing_alias` for non-interning alias lookup.
- Adds `get_alias_by_prefix` so SHA-prefix navigation can find an existing alias without stringifying and reinserting OIDs.
- Adds reserve/shrink helpers for alias storage.
- Updates app, graph service, walker, worktree, stash, navigation, and reflog paths to use the new alias APIs instead of directly reading `oids`/`aliases`.
- Updates heatmap generation to build from sorted aliases instead of directly reading the old raw OID vector.

Algorithm difference:

- Commit identity is still represented externally by small aliases in graph/UI structures.
- The backing identity store is now `gix::ObjectId` plus typed `iddqd` records instead of `git2::Oid` plus a standard hash map.
- Existing `git2` behavior is preserved by converting back to `git2::Oid` at remaining `git2` call sites.
- SHA-prefix lookup now validates hex input and compares prefix nibbles directly against stored object bytes instead of allocating/stringifying OIDs.
- Heatmap counting now uses fixed-size count arrays for the 53-week grid and can also be fed through a streaming `HeatmapCounts` helper.
- Graph ordering, alias identity, stash/reflog/worktree lookup, parent/child navigation, and heatmap semantics are intended to remain equivalent.

Performance story:

- This should reduce OID churn in the identity layer by centralizing OID ownership and avoiding repeated direct access to raw `git2::Oid` collections.
- Prefix lookup avoids `to_string().starts_with(...)` scans and uses byte/nibble comparison instead.
- Heatmap counting now avoids an intermediate map and uses a fixed-size array for the rendered grid.
- No whole-app speedup is claimed here. Any runtime win should be measured in the later graph/query PRs.

## Benchmark Results for this PR

Command shape: `hyperfine --warmup 5 './target/release/guitar /home/mjc/src/linux --exit-when-graph-complete'`.

### CPU: M1 MacBook Pro 16GB

| Ref | Total | vs main | User | System | CPU |
| --- | ---: | ---: | ---: | ---: | ---: |
| `02-gix-oids` | `1:14.26` | `2.12x` | `65.41s` | `2.17s` | `91%` |

### CPU: 5950x Linux/ZFS

| Ref | Total | vs main | User | System | CPU |
| --- | ---: | ---: | ---: | ---: | ---: |
| `02-gix-oids` | `1:10.85` | `1.40x` | `69.07s` | `1.78s` | `100%` |

### Memory: 5950x Linux/ZFS

| Ref | Peak heap | Peak RSS |
| --- | ---: | ---: |
| `02-gix-oids` | `1.38G` | `2.63G` |

<details>
<summary>Top 10 heaptrack allocation sites for `02-gix-oids`</summary>

1. `18210838 calls, 70.52M peak - git__calloc`
2. `17431852 calls, 21.44M peak - git__substrdup`
3. `6613871 calls, 18.44M peak - commit_parse`
4. `4576967 calls, 0B peak - inflateInit2_`
5. `4514697 calls, 265.92M peak - git__strndup`
6. `4209519 calls, 279.42K peak - git_commit_list_insert`
7. `2765451 calls, 366.68M peak - alloc::raw_vec::RawVecInner<>::finish_grow`
8. `2096782 calls, 0B peak - git_commit_list_insert_by_date`
9. `847866 calls, 472.20K peak - git_delta_apply`
10. `484765 calls, 24.61M peak - alloc::sync::Arc<>::make_mut`

</details>

