### PR TITLE
Handle missing git user.name/email without panicking

### DIFF
--- a/src/app/app.rs
+++ b/src/app/app.rs
@@ -970,8 +970,8 @@ impl App {
 
             // Commit actions require a concrete identity, so missing config is treated as fatal.
             let (name, email) = get_git_user_info(repo).expect("Couldn't get user credentials");
-            self.name = name.unwrap();
-            self.email = email.unwrap();
+            self.name = name;
+            self.email = email;
 
             // The spinner reflects walker activity, not individual git network commands.
             self.spinner.start();

--- a/src/app/draw/settings.rs
+++ b/src/app/draw/settings.rs
@@ -365,9 +365,9 @@ impl App {
         lines.push(self.settings_section_line(settings_text::CREDENTIALS(), width));
         lines.push(Line::default());
 
-        lines.push(self.settings_filled_line(settings_text::NAME(), format!("{} ", name.unwrap()).as_str(), width, shaded));
+        lines.push(self.settings_filled_line(settings_text::NAME(), format!("{name} ").as_str(), width, shaded));
         self.add_settings_selection(lines, SettingsSelectionKind::Info);
-        lines.push(self.settings_filled_line(settings_text::EMAIL(), format!("{} ", email.unwrap()).as_str(), width, plain));
+        lines.push(self.settings_filled_line(settings_text::EMAIL(), format!("{email} ").as_str(), width, plain));
         self.add_settings_selection(lines, SettingsSelectionKind::Info);
         lines.push(self.settings_filled_line(settings_text::AUTHORIZATION(), settings_text::SSH_AGENT_DETAIL(), width, shaded));
         self.add_settings_selection(lines, SettingsSelectionKind::Info);

--- a/src/git/queries/commits.rs
+++ b/src/git/queries/commits.rs
@@ -91,10 +91,12 @@ pub fn get_timestamps(repo: &Repository, _branches: &HashMap<Oid, Vec<String>>) 
         .collect()
 }
 
-pub fn get_git_user_info(repo: &Repository) -> Result<(Option<String>, Option<String>), git2::Error> {
+pub fn get_git_user_info(repo: &Repository) -> Result<(String, String), git2::Error> {
     let config = repo.config()?;
-    let name = config.get_string("user.name").ok();
-    let email = config.get_string("user.email").ok();
+    // Missing config falls back to empty strings; committing then surfaces libgit2's
+    // "empty name/email" error rather than attributing commits to an unconfigured identity.
+    let name = config.get_string("user.name").unwrap_or_default();
+    let email = config.get_string("user.email").unwrap_or_default();
     Ok((name, email))
 }
 


### PR DESCRIPTION
## Summary
- `get_git_user_info` now returns `(String, String)` instead of `(Option<String>, Option<String>)`, falling back to empty strings when `user.name`/`user.email` are unset in gitconfig.
- Removes the `.unwrap()` calls in `App` startup and the settings view that would panic when git identity config is absent.
- Committing with an empty identity now surfaces libgit2's own "empty name/email" error instead of crashing on startup.

## Test plan
- [ ] Run the app with a repo/global config that has no `user.name`/`user.email` set and confirm it starts without panicking
- [ ] Check the settings view renders empty name/email fields gracefully
- [ ] Attempt a commit action with missing identity and confirm a sensible error surfaces instead of a panic